### PR TITLE
Explicitly setting the maven-release-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
There is an issue where Maven is not committing the version changes after preparing for a release. Hopefully this fixes that issue.

Link to plugin releases:
https://issues.apache.org/jira/browse/MRELEASE/?selectedTab=com.atlassian.jira.jira-projects-plugin:versions-panel