### PR TITLE
Make sure that empty extension attributes don't make it to the final …

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+# Releases #
+
+## In Progress Work ##
+1. Fixed a bug where an empty extension attribute value creates a malformed SAMLResponse
+
+## Release 1.0.1 (2017-02-03) ##
+1. Set the issue to the SAML Response to a default value of http://openrepose.org/filters/SAMLTranslation
+
+## Release 1.0.0 (2017-02-01) ##
+1. Initial Release

--- a/core/src/main/resources/xsl/mapping.xsl
+++ b/core/src/main/resources/xsl/mapping.xsl
@@ -160,23 +160,26 @@
                     <xslout:variable name="extName" as="xs:string" select="."/>
                     <xslout:variable name="multiValueAttrib" as="attribute()?" select="($groups/element()[local-name(.)=$extName]/@multiValue)[1]"/>
                     <xslout:variable name="isMultiValue" select="if (exists($multiValueAttrib)) then xs:boolean($multiValueAttrib) else false()" as="xs:boolean"/>
-                    <xslout:element>
-                        <xsl:attribute name="name">{$extName}</xsl:attribute>
-                        <xslout:choose>
-                            <xslout:when test="$isMultiValue">
-                              <xslout:attribute name="value" select="string-join($groups/element()[local-name(.)=$extName]/@value,' ')"/>
-                            </xslout:when>
-                            <xslout:otherwise>
-                              <xslout:attribute name="value" select="($groups/element()[local-name(.)=$extName])[1]/@value"/>
-                            </xslout:otherwise>
-                        </xslout:choose>
-                        <xslout:for-each select="($groups/element()[local-name(.)=$extName])[1]/@*[not(local-name() = 'value')]">
-                            <xslout:attribute>
-                                <xsl:attribute name="name">{name(.)}</xsl:attribute>
-                                <xslout:value-of select="."/>
-                            </xslout:attribute>
-                        </xslout:for-each>
-                    </xslout:element>
+                    <xslout:variable name="values" as="xs:string*" select="if ($isMultiValue) then for $v in $groups/element()[local-name(.)=$extName]/@value return tokenize($v,' ') else ($groups/element()[local-name(.)=$extName])[1]/@value"/>
+                    <xslout:if test="not(empty($values)) and not($values='')">
+                        <xslout:element>
+                            <xsl:attribute name="name">{$extName}</xsl:attribute>
+                            <xslout:choose>
+                                <xslout:when test="$isMultiValue">
+                                    <xslout:attribute name="value" select="string-join($values,' ')"/>
+                                </xslout:when>
+                                <xslout:otherwise>
+                                    <xslout:attribute name="value" select="$values"/>
+                                </xslout:otherwise>
+                            </xslout:choose>
+                            <xslout:for-each select="($groups/element()[local-name(.)=$extName])[1]/@*[not(local-name() = 'value')]">
+                                <xslout:attribute>
+                                    <xsl:attribute name="name">{name(.)}</xsl:attribute>
+                                    <xslout:value-of select="."/>
+                                </xslout:attribute>
+                            </xslout:for-each>
+                        </xslout:element>
+                    </xslout:if>
                 </xslout:for-each>
             </xslout:template>
             <xslout:function name="mapping:get-attributes" as="xs:string*">

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- The issuer of the response should be Repose -->
+<?assert /saml2p:Response/saml2:Issuer = 'http://openrepose.org/filters/SAMLTranslation'?>
+
+<!-- The issuer of the first assertion should be Repose -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Issuer = 'http://openrepose.org/filters/SAMLTranslation'?>
+
+<!-- The issuer of the second assertion should be adfs trust -->
+<?assert /saml2p:Response/saml2:Assertion[2]/saml2:Issuer = 'http://adfs.contosowidgets.com/adfs/services/trust'?>
+
+<!-- The name should be btables@contosowidgets.loc -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID = 'btables@contosowidgets.loc'?>
+
+<!-- The email should be btables@contosowidgets.loc -->
+<?assert mapping:get-attribute('email') = 'btables@contosowidgets.loc'?>
+
+<!-- The domain should be set to 5821006 -->
+<?assert mapping:get-attribute('domain') = '5821006'?>
+
+<!-- The roles should be set -->
+<?assert every $r in ('Domain Users','RAX-identity~admin','RAX-nova~admin','RACK-Domain-5821005','Observer') satisfies $r=mapping:get-attributes('roles')?>
+
+<!-- Ensure that faws/observers is setup correctly -->
+<?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
+
+<!-- Ensure that faws/nones is not set -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones'])?>
+
+<!-- Ensure that faws/admins is not set -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins'])?>
+
+
+<samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
+    Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"
+    ID="_1105c5b8-28d4-45e5-a6e4-bc4179f5a111" IssueInstant="2016-11-18T18:54:55.572Z" Version="2.0"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1105c5b8-28d4-45e5-a6e4-bc4179f5a111">
+                <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>JaeeD+wkw297KPF+BKpdacRtaPmQKFD+DqXQ3JE3Aus=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>kDBwO3xYaxITVS7ZZIy9AGOlk16Y5E0BlqU12QlRpWGfiwjtgok4p5q3YQS+N/Pxh84JUIjd7i+n0to/2yJyaCfoSA2SIUUf448lTtHNzVmjiC4WiUmUTRGaxUpsdcYUkjFAVAS40yGDBLXMYn/JYS4cbRV52/RTJ5smCCpqBMjgzhVaeAqJif/gXGjvMLl4RFN8JGvHZGzpjCb14UdKhVqfP0ZumLo4cLIWd3Ch49zRBQBgchbFqEJbTdPPLTJ4SMIEYm5RwX4PtQ2Ce94u8IGXkIhYf32H43l+955a35XGh37hcZMLZEzjk4FBMqSScupKqDej1c0m34MkeRGMlQ==</ds:SignatureValue>
+        <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+                <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+            </ds:X509Data>
+        </KeyInfo>
+    </ds:Signature>
+    <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+    <Assertion ID="_a8a6920c-d4eb-467f-85df-6fa2767ae63d" IssueInstant="2016-11-18T18:54:55.571Z"
+        Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+        <Issuer>http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+                    <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>uQmSKQT03SRunafqzpb6v159a+jMVvTqmBCFYn17e7s=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>cYKqfE92hWqaPylJIcl89U9TKNzJXcFIPO0fvohg70zLB4JWnYlIKOz7S9XFUvS24mN47XS1T8DeR0IGITBMhqA/GCM624SOW0QjIRhQ9gh6/ONlyuAxGbVDo5tYb82sICFa9sMWI2Vr5ZH2LeTqyvsBRnlWBkZIw4hS2PBDHbhcnILUGX9uUDRcOrONAEMimnB7cNmZxSwQgdPfupyS39oedrUAiORa7GMII8GglWoj6Jy8SX0fQKXfsXD+wC5XFw76WAKJjSCuEkrXfxMQia/2H1tE24zNgZd6Y+uQ2Nh8YlUvO+DaMoj7mTKZUBqlxQt6It4kGH0+hfqvWx1MHQ==</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+                </ds:X509Data>
+            </KeyInfo>
+        </ds:Signature>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">btables@contosowidgets.loc</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData NotOnOrAfter="2016-11-18T18:59:55.572Z"
+                Recipient="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"/></SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2016-11-18T18:54:55.551Z" NotOnOrAfter="2016-11-18T19:54:55.551Z">
+            <AudienceRestriction>
+                <Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+                <AttributeValue>btables@contosowidgets.loc</AttributeValue>
+            </Attribute>
+            <Attribute Name="domain">
+                <AttributeValue>5821005</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+                <AttributeValue>Domain Users</AttributeValue>
+                <AttributeValue>RAX-identity~admin</AttributeValue>
+                <AttributeValue>RAX-nova~admin</AttributeValue>
+                <AttributeValue>RACK-Domain-5821005</AttributeValue>
+                <AttributeValue>Observer</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2016-11-18T18:30:55.359Z"
+            SessionIndex="_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+            <AuthnContext>
+                <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- The issuer of the response should be Repose -->
+<?assert /saml2p:Response/saml2:Issuer = 'http://openrepose.org/filters/SAMLTranslation'?>
+
+<!-- The issuer of the first assertion should be Repose -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Issuer = 'http://openrepose.org/filters/SAMLTranslation'?>
+
+<!-- The issuer of the second assertion should be adfs trust -->
+<?assert /saml2p:Response/saml2:Assertion[2]/saml2:Issuer = 'http://adfs.contosowidgets.com/adfs/services/trust'?>
+
+<!-- The name should be btables@contosowidgets.loc -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID = 'btables@contosowidgets.loc'?>
+
+<!-- The email should be btables@contosowidgets.loc -->
+<?assert mapping:get-attribute('email') = 'btables@contosowidgets.loc'?>
+
+<!-- The domain should be set to 5821006 -->
+<?assert mapping:get-attribute('domain') = '5821006'?>
+
+<!-- The roles should be set -->
+<?assert every $r in ('Domain Users','RAX-identity~admin','RAX-nova~admin','RACK-Domain-5821005','Admin') satisfies $r=mapping:get-attributes('roles')?>
+
+<!-- Ensure that faws/admins is set correctly -->
+<?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
+
+<!-- Ensure that faws/observers is setup correctly -->
+<?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
+
+<!-- Ensure that faws/nones is not set -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones'])?>
+
+<samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
+    Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"
+    ID="_1105c5b8-28d4-45e5-a6e4-bc4179f5a111" IssueInstant="2016-11-18T18:54:55.572Z" Version="2.0"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1105c5b8-28d4-45e5-a6e4-bc4179f5a111">
+                <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>JaeeD+wkw297KPF+BKpdacRtaPmQKFD+DqXQ3JE3Aus=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>kDBwO3xYaxITVS7ZZIy9AGOlk16Y5E0BlqU12QlRpWGfiwjtgok4p5q3YQS+N/Pxh84JUIjd7i+n0to/2yJyaCfoSA2SIUUf448lTtHNzVmjiC4WiUmUTRGaxUpsdcYUkjFAVAS40yGDBLXMYn/JYS4cbRV52/RTJ5smCCpqBMjgzhVaeAqJif/gXGjvMLl4RFN8JGvHZGzpjCb14UdKhVqfP0ZumLo4cLIWd3Ch49zRBQBgchbFqEJbTdPPLTJ4SMIEYm5RwX4PtQ2Ce94u8IGXkIhYf32H43l+955a35XGh37hcZMLZEzjk4FBMqSScupKqDej1c0m34MkeRGMlQ==</ds:SignatureValue>
+        <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+                <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+            </ds:X509Data>
+        </KeyInfo>
+    </ds:Signature>
+    <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+    <Assertion ID="_a8a6920c-d4eb-467f-85df-6fa2767ae63d" IssueInstant="2016-11-18T18:54:55.571Z"
+        Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+        <Issuer>http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+                    <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>uQmSKQT03SRunafqzpb6v159a+jMVvTqmBCFYn17e7s=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>cYKqfE92hWqaPylJIcl89U9TKNzJXcFIPO0fvohg70zLB4JWnYlIKOz7S9XFUvS24mN47XS1T8DeR0IGITBMhqA/GCM624SOW0QjIRhQ9gh6/ONlyuAxGbVDo5tYb82sICFa9sMWI2Vr5ZH2LeTqyvsBRnlWBkZIw4hS2PBDHbhcnILUGX9uUDRcOrONAEMimnB7cNmZxSwQgdPfupyS39oedrUAiORa7GMII8GglWoj6Jy8SX0fQKXfsXD+wC5XFw76WAKJjSCuEkrXfxMQia/2H1tE24zNgZd6Y+uQ2Nh8YlUvO+DaMoj7mTKZUBqlxQt6It4kGH0+hfqvWx1MHQ==</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+                </ds:X509Data>
+            </KeyInfo>
+        </ds:Signature>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">btables@contosowidgets.loc</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData NotOnOrAfter="2016-11-18T18:59:55.572Z"
+                Recipient="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"/></SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2016-11-18T18:54:55.551Z" NotOnOrAfter="2016-11-18T19:54:55.551Z">
+            <AudienceRestriction>
+                <Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+                <AttributeValue>btables@contosowidgets.loc</AttributeValue>
+            </Attribute>
+            <Attribute Name="domain">
+                <AttributeValue>5821005</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+                <AttributeValue>Domain Users</AttributeValue>
+                <AttributeValue>RAX-identity~admin</AttributeValue>
+                <AttributeValue>RAX-nova~admin</AttributeValue>
+                <AttributeValue>RACK-Domain-5821005</AttributeValue>
+                <AttributeValue>Admin</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2016-11-18T18:30:55.359Z"
+            SessionIndex="_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+            <AuthnContext>
+                <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- The issuer of the response should be Repose -->
+<?assert /saml2p:Response/saml2:Issuer = 'http://openrepose.org/filters/SAMLTranslation'?>
+
+<!-- The issuer of the first assertion should be Repose -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Issuer = 'http://openrepose.org/filters/SAMLTranslation'?>
+
+<!-- The issuer of the second assertion should be adfs trust -->
+<?assert /saml2p:Response/saml2:Assertion[2]/saml2:Issuer = 'http://adfs.contosowidgets.com/adfs/services/trust'?>
+
+<!-- The name should be btables@contosowidgets.loc -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID = 'btables@contosowidgets.loc'?>
+
+<!-- The email should be btables@contosowidgets.loc -->
+<?assert mapping:get-attribute('email') = 'btables@contosowidgets.loc'?>
+
+<!-- The domain should be set to 5821006 -->
+<?assert mapping:get-attribute('domain') = '5821006'?>
+
+<!-- The roles should be set -->
+<?assert every $r in ('Domain Users','RAX-identity~admin','RAX-nova~admin','RACK-Domain-5821005','Contractor') satisfies $r=mapping:get-attributes('roles')?>
+
+<!-- Ensure that faws/nones is setup correctly -->
+<?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
+
+<!-- Ensure that faws/observers is not set -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers'])?>
+
+<!-- Ensure that faws/admins is not set -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins'])?>
+
+
+<samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
+    Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"
+    ID="_1105c5b8-28d4-45e5-a6e4-bc4179f5a111" IssueInstant="2016-11-18T18:54:55.572Z" Version="2.0"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1105c5b8-28d4-45e5-a6e4-bc4179f5a111">
+                <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>JaeeD+wkw297KPF+BKpdacRtaPmQKFD+DqXQ3JE3Aus=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>kDBwO3xYaxITVS7ZZIy9AGOlk16Y5E0BlqU12QlRpWGfiwjtgok4p5q3YQS+N/Pxh84JUIjd7i+n0to/2yJyaCfoSA2SIUUf448lTtHNzVmjiC4WiUmUTRGaxUpsdcYUkjFAVAS40yGDBLXMYn/JYS4cbRV52/RTJ5smCCpqBMjgzhVaeAqJif/gXGjvMLl4RFN8JGvHZGzpjCb14UdKhVqfP0ZumLo4cLIWd3Ch49zRBQBgchbFqEJbTdPPLTJ4SMIEYm5RwX4PtQ2Ce94u8IGXkIhYf32H43l+955a35XGh37hcZMLZEzjk4FBMqSScupKqDej1c0m34MkeRGMlQ==</ds:SignatureValue>
+        <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+                <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+            </ds:X509Data>
+        </KeyInfo>
+    </ds:Signature>
+    <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+    <Assertion ID="_a8a6920c-d4eb-467f-85df-6fa2767ae63d" IssueInstant="2016-11-18T18:54:55.571Z"
+        Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+        <Issuer>http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+                    <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>uQmSKQT03SRunafqzpb6v159a+jMVvTqmBCFYn17e7s=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>cYKqfE92hWqaPylJIcl89U9TKNzJXcFIPO0fvohg70zLB4JWnYlIKOz7S9XFUvS24mN47XS1T8DeR0IGITBMhqA/GCM624SOW0QjIRhQ9gh6/ONlyuAxGbVDo5tYb82sICFa9sMWI2Vr5ZH2LeTqyvsBRnlWBkZIw4hS2PBDHbhcnILUGX9uUDRcOrONAEMimnB7cNmZxSwQgdPfupyS39oedrUAiORa7GMII8GglWoj6Jy8SX0fQKXfsXD+wC5XFw76WAKJjSCuEkrXfxMQia/2H1tE24zNgZd6Y+uQ2Nh8YlUvO+DaMoj7mTKZUBqlxQt6It4kGH0+hfqvWx1MHQ==</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+                </ds:X509Data>
+            </KeyInfo>
+        </ds:Signature>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">btables@contosowidgets.loc</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData NotOnOrAfter="2016-11-18T18:59:55.572Z"
+                Recipient="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"/></SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2016-11-18T18:54:55.551Z" NotOnOrAfter="2016-11-18T19:54:55.551Z">
+            <AudienceRestriction>
+                <Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+                <AttributeValue>btables@contosowidgets.loc</AttributeValue>
+            </Attribute>
+            <Attribute Name="domain">
+                <AttributeValue>5821005</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+                <AttributeValue>Domain Users</AttributeValue>
+                <AttributeValue>RAX-identity~admin</AttributeValue>
+                <AttributeValue>RAX-nova~admin</AttributeValue>
+                <AttributeValue>RACK-Domain-5821005</AttributeValue>
+                <AttributeValue>Contractor</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2016-11-18T18:30:55.359Z"
+            SessionIndex="_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+            <AuthnContext>
+                <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs-2.json
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs-2.json
@@ -1,0 +1,84 @@
+ {
+  "mapping": {
+    "version":"RAX-1",
+    "description":"The example shows one method of setting up multiple FAWS account\/policy\/role combinations.",
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress",
+            "multiValue":false
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value":"{0}",
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       },
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "anyOneOf":"Admin"
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "notAnyOf":"Contractor"
+           }
+         ],
+        "local": {
+          "faws": {
+            "admins": [
+                "12285\/AWSPolicy",
+                "38839\/AWSPolicy"
+               ]
+             }
+        }
+       },
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "notAnyOf":"Contractor"
+           }
+         ],
+        "local": {
+          "faws": {
+            "observers": [
+                "12285\/AWSPolicy",
+                "38839\/AWSPolicy"
+               ]
+          }
+        }
+       },
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "anyOneOf":"Contractor"
+           }
+         ],
+        "local": {
+          "faws": {
+            "nones":  [
+                "12285\/AWSPolicy",
+                "38839\/AWSPolicy"
+               ]
+           }
+        }
+       }
+     ]
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs-single-rule.json
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs-single-rule.json
@@ -1,0 +1,64 @@
+ {
+  "mapping": {
+    "version":"RAX-1",
+    "description":"The example shows one method of setting up multiple FAWS account\/policy\/role combinations.",
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress",
+            "multiValue":false
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value":"{0}",
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       },
+       {
+        "remote": [
+           {
+            "path":"if (mapping:get-attributes('http:\/\/schemas.xmlsoap.org\/claims\/Group')='Admin') then ('12285\/AWSPolicy','38839\/AWSPolicy') else ()",
+            "multiValue":true
+           },
+           {
+            "path":"if (not(mapping:get-attributes('http:\/\/schemas.xmlsoap.org\/claims\/Group')='Contractor')) then ('12285\/AWSPolicy','38839\/AWSPolicy') else ()",
+            "multiValue":true
+           },
+           {
+            "path":"if (mapping:get-attributes('http:\/\/schemas.xmlsoap.org\/claims\/Group')='Contractor') then ('12285\/AWSPolicy','38839\/AWSPolicy') else ()",
+            "multiValue":true
+           }
+         ],
+        "local": {
+          "faws": {
+            "admins": {
+              "value":"{0}",
+              "multiValue":true
+            },
+            "observers": {
+              "value":"{1}",
+              "multiValue":true
+            },
+           "nones": {
+              "value":"{2}",
+              "multiValue":true
+             }
+           }
+         }
+       }
+     ]
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs-single-rule.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs-single-rule.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+    <description>
+        The example shows one method of setting up multiple FAWS
+        account/policy/role combinations.
+    </description>
+    <rules>
+        <rule>
+            <local>
+                <user>
+                    <domain value="5821006"/>
+                    <name value="{D}"/>
+                    <email value="{1}"/>
+                    <roles value="{0}" multiValue="true"/>
+                    <expire value="{D}"/>
+                </user>
+            </local>
+            <remote>
+                <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+                <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+            </remote>
+        </rule>
+        <rule>
+            <local>
+                <faws xsi:type="LocalAttributeGroup">
+                    <admins    value="{0}" multiValue="true" xsi:type="LocalAttribute"/>
+                    <observers value="{1}" multiValue="true" xsi:type="LocalAttribute"/>
+                    <nones     value="{2}" multiValue="true" xsi:type="LocalAttribute"/>
+                </faws>
+            </local>
+            <remote>
+                <attribute multiValue="true"
+                           path="if (mapping:get-attributes('http://schemas.xmlsoap.org/claims/Group')='Admin') then ('12285/AWSPolicy','38839/AWSPolicy') else ()"/>
+                <attribute multiValue="true"
+                           path="if (not(mapping:get-attributes('http://schemas.xmlsoap.org/claims/Group')='Contractor')) then ('12285/AWSPolicy','38839/AWSPolicy') else ()"/>
+                <attribute multiValue="true"
+                           path="if (mapping:get-attributes('http://schemas.xmlsoap.org/claims/Group')='Contractor') then ('12285/AWSPolicy','38839/AWSPolicy') else ()"/>
+            </remote>
+        </rule>
+    </rules>
+</mapping>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs.json
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs.json
@@ -1,0 +1,99 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "regex":false,
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "regex":false,
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress",
+            "multiValue":false
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value":"{0}",
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       },
+       {
+        "remote": [
+           {
+            "regex":false,
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "anyOneOf":"Admin"
+           },
+           {
+            "regex":false,
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "notAnyOf":"Contractor"
+           }
+         ],
+        "local": {
+          "faws": {
+            "admins": {
+              "value": [
+                "12285\/AWSPolicy",
+                "38839\/AWSPolicy"
+               ],
+              "multiValue":true
+             }
+           }
+         }
+       },
+       {
+        "remote": [
+           {
+            "regex":false,
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "notAnyOf":"Contractor"
+           }
+         ],
+        "local": {
+          "faws": {
+            "observers": {
+              "value": [
+                "12285\/AWSPolicy",
+                "38839\/AWSPolicy"
+               ],
+              "multiValue":true
+             }
+           }
+         }
+       },
+       {
+        "remote": [
+           {
+            "regex":false,
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "anyOneOf":"Contractor"
+           }
+         ],
+        "local": {
+          "faws": {
+            "nones": {
+              "value": [
+                "12285\/AWSPolicy",
+                "38839\/AWSPolicy"
+               ],
+              "multiValue":true
+             }
+           }
+         }
+       }
+     ],
+    "version":"RAX-1",
+    "description":"\n        The example shows one method of setting up multiple FAWS\n        account\/policy\/role combinations.\n    "
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/maps/adfs.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+    <description>
+        The example shows one method of setting up multiple FAWS
+        account/policy/role combinations.
+    </description>
+    <rules>
+        <rule>
+            <local>
+                <user>
+                    <domain value="5821006"/>
+                    <name value="{D}"/>
+                    <email value="{1}"/>
+                    <roles value="{0}" multiValue="true"/>
+                    <expire value="{D}"/>
+                </user>
+            </local>
+            <remote>
+                <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+                <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+            </remote>
+        </rule>
+        <rule>
+            <local>
+                <faws xsi:type="LocalAttributeGroup">
+                    <admins value="12285/AWSPolicy 38839/AWSPolicy" multiValue="true" xsi:type="LocalAttribute"/>
+                </faws>
+            </local>
+            <remote>
+                <attribute name="http://schemas.xmlsoap.org/claims/Group" anyOneOf="Admin"/>
+                <attribute name="http://schemas.xmlsoap.org/claims/Group" notAnyOf="Contractor"/>
+            </remote>
+        </rule>
+        <rule>
+            <local>
+                <faws xsi:type="LocalAttributeGroup">
+                    <observers value="12285/AWSPolicy 38839/AWSPolicy" multiValue="true" xsi:type="LocalAttribute"/>
+                </faws>
+            </local>
+            <remote>
+                <attribute name="http://schemas.xmlsoap.org/claims/Group" notAnyOf="Contractor"/>
+            </remote>
+        </rule>
+        <rule>
+            <local>
+                <faws xsi:type="LocalAttributeGroup">
+                    <nones value="12285/AWSPolicy 38839/AWSPolicy" multiValue="true" xsi:type="LocalAttribute"/>
+                </faws>
+            </local>
+            <remote>
+                <attribute name="http://schemas.xmlsoap.org/claims/Group" anyOneOf="Contractor"/>
+            </remote>
+        </rule>
+    </rules>
+</mapping>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/asserts/sample_assert.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- There should be two assertions -->
+<?assert count(/saml2p:Response/saml2:Assertion) = 2 ?>
+
+<!-- There should be a single nova:admin attribute -->
+<?assert mapping:get-attributes('roles')='nova:admin' and count(mapping:get-attributes('roles'))=1?>
+
+<!-- The name should be john.doe -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID = 'john.doe'?>
+
+<!-- The message should expire at 2013-11-17T16:19:06.298Z -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2013-11-17T16:19:06.298Z'?>
+
+<!-- The email should be no-reply@rackspace.com -->
+<?assert mapping:get-attribute('email') = 'no-reply@rackspace.com'?>
+
+<!-- The email should be no-reply@rackspace.com -->
+<?assert mapping:get-attribute('domain') = '323676'?>
+
+<!-- The extended attribute foo should contain a date that is in the future -->
+<?assert xs:dateTime(mapping:get-attribute('user/foo')) > current-dateTime()?>
+
+<!-- The extended attribute foo should contain a date no longer than 2 hours in the future -->
+<?assert (xs:dateTime(mapping:get-attribute('user/foo')) - current-dateTime()) <= xs:dayTimeDuration('PT2H')?>
+
+<!-- There should exist 0 FAWS policies -->
+<?assert count(mapping:get-attributes('faws/policy')) = 0 ?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/maps/mapping-rule-ext-attribute4.json
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/maps/mapping-rule-ext-attribute4.json
@@ -1,0 +1,47 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "path":"'PT'",
+            "regex":false,
+            "multiValue":false
+           },
+           {
+            "path":"()",
+            "regex":false,
+            "multiValue":false
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"{D}",
+            "foo": {
+              "value":"{0}2H",
+              "type":"xs:dateTime"
+             },
+            "name":"{D}",
+            "email":"{D}",
+            "roles":"{D}",
+            "expire":"{D}"
+           },
+          "faws": {
+            "policy":"{1}"
+           }
+         }
+       },
+       {
+        "local": {
+          "user": {
+            
+           },
+          "faws": {
+            "policy":"AWSPolicy2"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/maps/mapping-rule-ext-attribute4.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/maps/mapping-rule-ext-attribute4.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+                <name value="{D}"/>
+                <email value="{D}"/>
+                <expire value="{D}"/>
+                <domain value="{D}"/>
+                <roles value="{D}"/>
+                <!--
+                    foo is not a standard role, the attribute will still be captured,
+                    The attribute name will be user/foo Because it's the attribute foo
+                    in the user group!
+
+                    It is an error to use {D} on an extended attribute, because it has no default!
+                    You can, however, do something like {D(name)} which gets the default for a standard
+                    attribute.
+
+                    The default is to have a type of xs:string and to not be multi-valued.
+                -->
+                <foo value="{0}2H" xsi:type="LocalAttribute" type="xs:dateTime"/>
+            </user>
+            <!--
+                faws is an extended attribute group
+
+                Extended groups are there for organizational purposes. They hold
+                extended attributes like foo above.
+            -->
+
+            <faws xsi:type="LocalAttributeGroup">
+                <policy value="{1}" xsi:type="LocalAttribute"/>
+            </faws>
+        </local>
+        <remote>
+            <attribute path="'PT'"/>
+            <attribute path="()"/>
+        </remote>
+      </rule>
+      <rule>
+        <local>
+            <user/>
+            <faws xsi:type="LocalAttributeGroup">
+                <policy value="AWSPolicy2" xsi:type="LocalAttribute"/>
+            </faws>
+        </local>
+      </rule>
+   </rules>
+</mapping>


### PR DESCRIPTION
…SAML

This only applyies to extended attributes for now.  Non-extended
attributes are always required.  Added adfs-faws-ext1 example which
shows an actual FAWS example where this comes into play.