### PR TITLE
Set the classloader to be AttributeMapper's classloader.

### DIFF
--- a/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
+++ b/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
@@ -72,7 +72,12 @@ object XSDEngine extends Enumeration {
 import XSDEngine._
 
 object AttributeMapper {
-  val processor = new Processor(true)
+  val processor = {
+    val p = new Processor(true)
+    val dynLoader = p.getUnderlyingConfiguration.getDynamicLoader
+    dynLoader.setClassLoader(getClass.getClassLoader)
+    p
+  }
 
   val compiler = processor.newXsltCompiler
   val xqueryCompiler = {


### PR DESCRIPTION
You can’t generate bytecode without using a classloader to get to the bytecode.  Saxon was creating a classloader to load generated bytecode with the wrong parent classloader…not sure why?  Here we tell saxon to use the classloader that AttributeMapper has as the parent -- that fixes issue with Repose.