### PR TITLE
Json validate call

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 1. Clean up : Better reporting of failed tests
 1. Clean up : Reuse common assertions in test suite
 1. Clean up : Add .DS_Store to .gitignore
+1. Fixed bug in JSON to XML Convertion of attribute policy
+1. Adding new call to validate policy given a JSONNode
 
 ## Release 1.0.2 (2017-02-20) ##
 1. Fixed a bug where an empty extension attribute value creates a malformed SAMLResponse

--- a/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
+++ b/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.io.OutputStream
 import java.io.Writer
 import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
 
 import javax.xml.transform.Source
 import javax.xml.transform.stream.StreamSource
@@ -185,6 +186,21 @@ object AttributeMapper {
 
   def validatePolicy (policy : Source, engineStr : String) : Source = {
     validate(policy, engineStr, mappingSchema, mappingSchemaManager)
+  }
+
+  def validatePolicy (policy : JsonNode, engineStr : String) : JsonNode = {
+    val outXMLPolicy = new XdmDestination
+
+    policy2XML(policy, outXMLPolicy)
+    val valXMLPolicySrc = validatePolicy(outXMLPolicy.getXdmNode.asSource, engineStr)
+
+    val bout = new ByteArrayOutputStream
+    val dest = processor.newSerializer(bout)
+
+    policy2JSON(valXMLPolicySrc, dest, false, engineStr)
+
+    val bin = new ByteArrayInputStream(bout.toByteArray)
+    parseJsonNode(new StreamSource(bin))
   }
 
   def generateXSL (policy : Source, xsl : Destination, isJSON : Boolean, validate : Boolean, xsdEngine : String) : Unit = {

--- a/core/src/test/scala/com/rackspace/identity/components/AttributeMapperSuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/AttributeMapperSuite.scala
@@ -94,7 +94,11 @@ class AttributeMapperSuite extends AttributeMapperBase {
       val policyExec : XsltExecutable = {
         if (isJSON) {
           val om = new ObjectMapper()
-          AttributeMapper.generateXSLExec (om.readTree(map), true, v)
+          val jsonPolicy = om.readTree(map)
+          //
+          //  We double validate to make sure validation call works
+          //
+          AttributeMapper.generateXSLExec (AttributeMapper.validatePolicy(jsonPolicy, v), true, v)
         } else {
           AttributeMapper.generateXSLExec (docBuilder.parse(map), true, v)
         }

--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -123,7 +123,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
         <parameters>
-            <parameter name="maxMethods"><![CDATA[30]]></parameter>
+            <parameter name="maxMethods"><![CDATA[45]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>


### PR DESCRIPTION
Added a call to allow the validation of a JSON policy directly.  Eventually, I'll extend to use JSONSchema, etc.  For now convert to XML then validate.

As part of testing call, realized that there was a bug in JSON -> XML conversion of policy.  Bug fix is included here as well.