### PR TITLE
Upgrade to latest version of Saxon.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,10 @@
 # Releases #
+## In Progress Work ##
+1. Updated Dependencies
+    1. saxon: 9.7.0-8 → 9.8.0-4
+    1. wadl-tools: 1.0.33 → 1.0.37
+    1. checker-util: 2.1.1 → 2.4.0
+1. Fixed a bug where we checked XPath syntax against XPath 3.1 but only supported 2.0 -- we now support XPath 3.1 fully.
 
 ## Release 1.3.0 (2017-08-14) ##
 1. Fixed a bug when converting values with {(P|A)ts()} from XML to JSON

--- a/core/src/main/resources/xsl/mapping.xsl
+++ b/core/src/main/resources/xsl/mapping.xsl
@@ -6,7 +6,7 @@
     xmlns:mapping="http://docs.rackspace.com/identity/api/ext/MappingRules"
     xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    version="2.0">
+    version="3.0">
     
     <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
@@ -17,7 +17,7 @@
             -  THIS IS A GENERATED TRANSFORM  DON'T EDIT BY HAND    -
             -                                                       -
         </xsl:comment>
-        <xslout:transform version="2.0" xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+        <xslout:transform version="3.0" xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
             <xsl:copy-of select="/mapping:mapping/namespace::*"/>
             <xslout:param name="outputSAML" as="xs:boolean" select="false()"/>
             <xslout:param name="issuer" as="xs:string" select="'http://openrepose.org/filters/SAMLTranslation'"/>

--- a/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
+++ b/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
@@ -95,7 +95,6 @@ object AttributeMapper {
   val compiler = processor.newXsltCompiler
   val xqueryCompiler = {
     val c = processor.newXQueryCompiler
-    c.setLanguageVersion(XQUERY_VERSION_STRING)
     c
   }
   private val internalXPathCompiler = {

--- a/core/src/test/scala/com/rackspace/identity/components/ExpressionProcessorTest.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/ExpressionProcessorTest.scala
@@ -35,6 +35,6 @@ class ExpressionProcessorTest extends FunSuite {
       count += 1
     })
 
-    assert(count == 4)
+    assert(count == 3)
   }
 }

--- a/core/src/test/scala/com/rackspace/identity/components/ValidatePolicySuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/ValidatePolicySuite.scala
@@ -59,7 +59,7 @@ class ValidatePolicySuite extends AttributeMapperBase {
         assert(
           m.contains("is not allowed in a policy path") ||
             m.contains("is not available with this host-language/version/license") ||
-            m.matches("Cannot find a matching \\d-argument function .*"),
+            m.matches("Cannot find a \\d-argument function .*"),
           "A function in a policy path is illegal")
       }
 
@@ -72,7 +72,7 @@ class ValidatePolicySuite extends AttributeMapperBase {
         assert(
           m.contains("is not allowed in a policy path") ||
             m.contains("is not available with this host-language/version/license") ||
-            m.matches("Cannot find a matching \\d-argument function .*"),
+            m.matches("Cannot find a \\d-argument function .*"),
           "A function in a policy path is illegal")
       }
 
@@ -85,7 +85,7 @@ class ValidatePolicySuite extends AttributeMapperBase {
         assert(
           m.contains("is not allowed in a policy path") ||
             m.contains("is not available with this host-language/version/license") ||
-            m.matches("Cannot find a matching \\d-argument function .*"),
+            m.matches("Cannot find a \\d-argument function .*"),
           "A function in a policy path is illegal")
       }
     }
@@ -117,7 +117,7 @@ class ValidatePolicySuite extends AttributeMapperBase {
         assert(
           m.contains("is not allowed in a policy path") ||
             m.contains("is not available with this host-language/version/license") ||
-            m.matches("Cannot find a matching \\d-argument function .*"),
+            m.matches("Cannot find a \\d-argument function .*"),
           "A function in a policy path is illegal")
       }
 
@@ -131,7 +131,7 @@ class ValidatePolicySuite extends AttributeMapperBase {
         assert(
           m.contains("is not allowed in a policy path") ||
             m.contains("is not available with this host-language/version/license") ||
-            m.matches("Cannot find a matching \\d-argument function .*"),
+            m.matches("Cannot find a \\d-argument function .*"),
           "A function in a policy path is illegal")
       }
 
@@ -145,7 +145,7 @@ class ValidatePolicySuite extends AttributeMapperBase {
         assert(
           m.contains("is not allowed in a policy path") ||
             m.contains("is not available with this host-language/version/license") ||
-            m.matches("Cannot find a matching \\d-argument function .*"),
+            m.matches("Cannot find a \\d-argument function .*"),
           "A function in a policy path is illegal")
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
         <scala.minor>11</scala.minor>
         <scala.patch>7</scala.patch>
         <scala.MajDotMin>${scala.major}.${scala.minor}</scala.MajDotMin>
-        <saxon-ee.version>9.7.0-8</saxon-ee.version>
+        <saxon-ee.version>9.8.0-4</saxon-ee.version>
         <scala.test.version>2.2.6</scala.test.version>
-        <wadl-tools.version>1.0.33</wadl-tools.version>
+        <wadl-tools.version>1.0.37</wadl-tools.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <scala-logging.version>2.1.2</scala-logging.version>
         <slf4j.version>1.7.7</slf4j.version>
@@ -58,7 +58,7 @@
         <json-schema-validator.version>2.1.7</json-schema-validator.version>
         <junit.version>4.10</junit.version>
         <mockito.version>1.9.0</mockito.version>
-        <checker-util.version>2.1.1</checker-util.version>
+        <checker-util.version>2.4.0</checker-util.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Note that this actually fixes a bug.  The previous version of
attribute-mapper was checking syntax against XPath 3.1, but only
allowed XPath 2.0 at runtime.

This brings alignment so that XPath 3.1 is allowed at both compile and
runtime.