### PR TITLE
Reworked how we get default values.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Releases #
+## In Progress Work ##
+1. Added the ability to specify default values ({D}) via configuration (defaults.xml) for standard attributes. Several places may be searched for values via XPath, SAML attribute name, or via passed in parameters.
+
 ## Release 1.3.1 (2017-08-29) ##
 1. Updated Dependencies
     1. saxon: 9.7.0-8 → 9.8.0-4

--- a/core/src/main/resources/xsd/defaults.xsd
+++ b/core/src/main/resources/xsd/defaults.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:mapping="http://docs.rackspace.com/identity/api/ext/MappingRules"
+    xmlns:saxon="http://saxon.sf.net/" xmlns:xerces="http://xerces.apache.org"
+    targetNamespace="http://docs.rackspace.com/identity/api/ext/MappingRules"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" vc:minVersion="1.1"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning">
+
+    <xs:element name="attribute-defaults" type="mapping:AttributeDefaults"/>
+
+    <xs:complexType name="AttributeDefaults">
+        <xs:sequence>
+            <xs:element name="attribute" type="mapping:AttributeDefaultDef" minOccurs="1"
+                maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:assert test="every $att in ('name','email','domain','expire', 'roles') satisfies mapping:attribute[@name=$att]"
+                   saxon:message="Every standard attribute (name, email, domain, expire, and roles) must have a default"
+                   xerces:message="Every standard attribute (name, email, domain, expire, and roles) must have a default"
+                   />
+        <xs:assert test="count(mapping:attribute/@name) = count(distinct-values(mapping:attribute/@name))"
+                   saxon:message="Attributes should not be listed more than once"
+                   xerces:message="Attributes should not be listed more than once"
+                   />
+    </xs:complexType>
+
+    <xs:complexType name="AttributeDefaultDef">
+        <xs:sequence>
+            <xs:element name="location" type="mapping:AttributeLocation" minOccurs="1"
+                maxOccurs="unbounded">
+                <xs:alternative test="@xpath" type="mapping:AttributeLocationXPath"/>
+                <xs:alternative test="@saml-attribute" type="mapping:AttributeLocationSAMLAttribute"/>
+                <xs:alternative test="@param" type="mapping:AttributeLocationParameter"/>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="mapping:AllowedAttributes" use="required"/>
+        <xs:attribute name="multiValue" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="AttributeLocation" abstract="true"/>
+
+    <xs:complexType name="AttributeLocationXPath">
+        <xs:complexContent>
+            <xs:extension base="mapping:AttributeLocation">
+                <xs:attribute name="xpath" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="AttributeLocationSAMLAttribute">
+        <xs:complexContent>
+            <xs:extension base="mapping:AttributeLocation">
+                <xs:attribute name="saml-attribute" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="AttributeLocationParameter">
+        <xs:complexContent>
+            <xs:extension base="mapping:AttributeLocation">
+                <xs:attribute name="param" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+
+    <xs:simpleType name="AllowedAttributes">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="name"/>
+            <xs:enumeration value="expire"/>
+            <xs:enumeration value="email"/>
+            <xs:enumeration value="domain"/>
+            <xs:enumeration value="roles"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/core/src/main/resources/xsl/defaults.xml
+++ b/core/src/main/resources/xsl/defaults.xml
@@ -1,0 +1,118 @@
+<!--
+  defaults.xml
+
+  This file defines what happens when attribmap sees a Squiggly-D
+  ({D}) in the mapping policy file.  Squiggly-D is essentailly asking
+  the policy to look for a value in a default place, and this defines
+  the default places to search for a value.
+
+  Defaults are always searched in order.  The location of the default
+  value may be a SAML attribute name, an XPath, or a parameter.
+  The first to correctly evaluate to a value will be used as the
+  default.
+
+  Paramaters are passed to attribmap as a collection
+  of name value pairs, they work like other locations (names, xpaths)
+  if a param exists the value will be used, if not, the next location
+  will be tried.
+
+  For now, namespaces available to XPaths must be defined in the root
+  element of this file.
+
+  For now, you are allowed to set defaults only for standard
+  attributes.  Setting defaults for extended attributes is not
+  supported.
+
+  For now, this configuration is not dynamic, it is examined when
+  attribute mapping library itself is compiled.
+
+  Copyright 2017 Rackspace US, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE attribute-defaults [
+<!ENTITY emailLocations '
+    <location saml-attribute="email"/>
+    <location saml-attribute="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+    <location saml-attribute="urn:oid:1.2.840.113549.1.9.1.1"/>
+    <location saml-attribute="0.9.2342.19200300100.1.3"/>
+  '>
+]>
+<attribute-defaults
+    xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+    xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
+
+    <attribute name="name">
+        <!--
+            A Subject's NameID who's type is not persistant or
+            transient, can be used as the default name.
+
+            We don't allow persistent because these names must not be
+            shared in the clear and we make no such protections.
+
+            We don't allow transient because these change from one
+            response to the next.
+
+            Attribmap will always send the name over as unspecified.
+        -->
+        <location
+            xpath="(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:NameID[not(@Format=('urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+                   'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'))])[1]"/>
+        <!--
+            If that doesn't work try various places for name and email
+            address.
+        -->
+        <location saml-attribute="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"/>
+        <!-- Principal Name -->
+        <location saml-attribute="urn:oid:1.3.6.1.4.1.5923.1.1.1.6"/>
+        <!-- Defined Above -->
+        &emailLocations;
+    </attribute>
+
+    <attribute name="email">
+        <!-- Defined Above -->
+        &emailLocations;
+    </attribute>
+
+    <attribute name="expire">
+        <location
+            xpath="
+                   (:
+                      Get all the relevant dates and convert to dateTimes. If there
+                      are multiple assertions in the response, this looks at all dates
+                      in all assertions.
+                   :)
+                   let $dates :=  for $d in (/saml2p:Response/saml2:Assertion/saml2:AuthnStatement/@SessionNotOnOrAfter,
+                                             /saml2p:Response/saml2:Assertion/saml2:Conditions/@NotOnOrAfter,
+                                             /saml2p:Response/saml2:Assertion/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter)
+                                             return xs:dateTime($d)
+
+                   (:
+                     If for some strange reason we couldn't find a single date
+                     return an hour duration, otherwise return the date that's
+                     closest to now.
+                   :)
+                   return if (empty($dates)) then 'PT1H' else min($dates)
+                   "/>
+    </attribute>
+
+    <attribute name="domain">
+        <location saml-attribute="domain"/>
+        <location param="domain"/>
+    </attribute>
+
+    <attribute name="roles" multiValue="true">
+        <location saml-attribute="roles"/>
+    </attribute>
+</attribute-defaults>

--- a/core/src/test/resources/defaults-ns.xml
+++ b/core/src/test/resources/defaults-ns.xml
@@ -1,0 +1,65 @@
+<!--
+  defaults.xml
+
+  This file defines what happens when attribmap sees a Squiggly-D
+  ({D}) in the mapping policy file.  Squiggly-D is essentailly asking
+  the policy to look for a value in a default place, and this defines
+  the default places to search for a value.
+
+  Defaults are always searched in order.  The location of the default
+  value may be a SAML attribute name or an XPath but cannot be both.
+  The first to correctly evaluate to a value will be used as the
+  default.
+
+  For now, namespaces available to XPaths must be defined in the root
+  element of this file.
+
+  For now, you are allowed to set defaults only for standard
+  attributes.
+
+  For now, this configuration is not dynamic, it is examined when
+  attribute mapping library itself is compiled.
+
+  Copyright 2017 Rackspace US, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<attribute-defaults
+    xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+    xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:foo="bar"
+    xmlns:x="yz">
+
+    <attribute name="name">
+        <location xpath="(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:NameID)[1]"/>
+    </attribute>
+
+    <attribute name="expire">
+        <location
+            xpath="(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter)[1]"/>
+    </attribute>
+
+    <attribute name="email">
+        <location saml-attribute="email"/>
+    </attribute>
+
+    <attribute name="domain">
+        <location saml-attribute="domain"/>
+    </attribute>
+
+    <attribute name="roles" multiValue="true">
+        <location saml-attribute="roles"/>
+    </attribute>
+</attribute-defaults>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email1.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email1.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email2.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email2.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- The email should be no-foo@rackspace.com -->
+<?assert mapping:get-attribute('email') = 'no-foo@rackspace.com'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email3.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email3.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- The email should be no-foo@rackspace.com -->
+<?assert mapping:get-attribute('email') = 'no-foo@rackspace.com'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="urn:oid:1.2.840.113549.1.9.1.1">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email4.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email4.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- The email should be no-foo@rackspace.com -->
+<?assert mapping:get-attribute('email') = 'no-foo@rackspace.com'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="urn:oid:1.2.840.113549.1.9.1.1">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire1.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire1.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- Expire should pick date from conditions -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2013-11-17T16:18:06.298Z'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z" SessionNotOnOrAfter="2013-12-17T16:19:06.298Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:Conditions NotBefore="2012-11-17T16:18:06.298Z"
+                      NotOnOrAfter="2013-11-17T16:18:06.298Z">
+        <saml2:AudienceRestriction>
+                <saml2:Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</saml2:Audience>
+        </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire2.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire2.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- Expire should pick date from AuthNStatement -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2013-11-17T16:17:06.298Z'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z" SessionNotOnOrAfter="2013-11-17T16:17:06.298Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:Conditions NotBefore="2012-11-17T16:18:06.298Z"
+                      NotOnOrAfter="2013-11-17T16:18:06.298Z">
+        <saml2:AudienceRestriction>
+                <saml2:Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</saml2:Audience>
+        </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire3.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire3.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- Expire should pick date from Subject -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2012-11-17T16:19:06.298Z'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2012-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z" SessionNotOnOrAfter="2013-11-17T16:17:06.298Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:Conditions NotBefore="2012-11-17T16:18:06.298Z"
+                      NotOnOrAfter="2013-11-17T16:18:06.298Z">
+        <saml2:AudienceRestriction>
+                <saml2:Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</saml2:Audience>
+        </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire4.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire4.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml#repose?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- Expire should pick date from Subject, in the 2nd assertion! -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2011-11-17T16:19:06.298Z'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2012-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z" SessionNotOnOrAfter="2013-11-17T16:17:06.298Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:Conditions NotBefore="2012-11-17T16:18:06.298Z"
+                      NotOnOrAfter="2013-11-17T16:18:06.298Z">
+        <saml2:AudienceRestriction>
+                <saml2:Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</saml2:Audience>
+        </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+    </saml2:Assertion>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a6" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2011-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z" SessionNotOnOrAfter="2013-11-17T16:17:06.298Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:Conditions NotBefore="2012-11-17T16:18:06.298Z"
+                      NotOnOrAfter="2013-11-17T16:18:06.298Z">
+        <saml2:AudienceRestriction>
+                <saml2:Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</saml2:Audience>
+        </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire5.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire5.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- If no dates are given the expire should be no longer than 1 hour in the future  -->
+<?assert (mapping:get-expire() - current-dateTime()) <= xs:dayTimeDuration('PT1H')?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData  />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z" >
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:Conditions NotBefore="2012-11-17T16:18:06.298Z"
+                      >
+        <saml2:AudienceRestriction>
+                <saml2:Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</saml2:Audience>
+        </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name1.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name1.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- If the format is persistent use email address instead of name -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-reply@rackspace.com'?>
+
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name2.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name2.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- If the format is transient use email address instead of name -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-reply@rackspace.com'?>
+
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name3.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name3.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- If the format is transient prefer claim name over email -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-foo-2@rackspace.com'?>
+
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo-2@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name4.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name4.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- If the format is transient prefer claim name over urn:oid:1.3.6.1.4.1.5923.1.1.1.6 -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-foo-2@rackspace.com'?>
+
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">joe.user.inside@amiga.org</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-foo-2@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-nodomain.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-nodomain.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+
+<!-- The param value should be input for the domain -->
+<?assert mapping:get-attribute('domain') = 'foo:999-882'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/scala/com/rackspace/identity/components/AttributeMapperSuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/AttributeMapperSuite.scala
@@ -82,7 +82,7 @@ class AttributeMapperSuite extends AttributeMapperBase {
       dest,
       true,
       true,
-      v)
+      v, Map("domain"->"foo:999-882"))
     dest.getXdmNode.asSource
   })
 
@@ -110,7 +110,7 @@ class AttributeMapperSuite extends AttributeMapperBase {
           AttributeMapper.generateXSLExec (docBuilder.parse(map), true, v)
       }
 
-      val resultDoc = AttributeMapper.convertAssertion (policyExec, docBuilder.parse(assertFile))
+      val resultDoc = AttributeMapper.convertAssertion (policyExec, docBuilder.parse(assertFile), Map("domain"->"foo:999-882"))
       new DOMSource(resultDoc)
     } finally {
       if (docBuilder != null) returnParser(docBuilder)

--- a/core/src/test/scala/com/rackspace/identity/components/ValidateDefaultsSuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/ValidateDefaultsSuite.scala
@@ -1,0 +1,108 @@
+/**
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.identity.components
+
+import java.io.File
+
+import javax.xml.validation.{Schema, SchemaFactory}
+
+import javax.xml.transform.stream.StreamSource
+
+import net.sf.saxon.s9api._
+
+import org.scalatest.FunSuite
+import org.scalatest.exceptions.TestFailedException
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import org.w3c.dom.Document
+
+import javax.xml.parsers.DocumentBuilder
+
+import javax.xml.xpath.XPathExpression
+import javax.xml.xpath.XPathConstants
+
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+import com.rackspace.com.papi.components.checker.util.XPathExpressionPool._
+
+import AttributeMapperBase._
+
+@RunWith(classOf[JUnitRunner])
+class ValidateDefaultsSuite extends AttributeMapperBase {
+
+  private lazy val schemaFactory = {
+    val sf = SchemaFactory.newInstance("http://www.w3.org/XML/XMLSchema/v1.1", "org.apache.xerces.jaxp.validation.XMLSchema11Factory",
+                              this.getClass.getClassLoader)
+    //
+    //  Enable CTA full XPath2.0 checking in XSD 1.1
+    //
+    sf.setFeature ("http://apache.org/xml/features/validation/cta-full-xpath-checking", true)
+    sf
+  }
+
+  private lazy val defaultsSchema = schemaFactory.newSchema(new StreamSource(getClass.getResource("/xsd/defaults.xsd").toString))
+
+  private val mapperXsltExec = AttributeMapper.compiler.compile(new StreamSource(getClass.getResource("/xsl/mapping.xsl").toString))
+
+  //
+  //  This test fails if defaults.xml is not valid according to the
+  //  schema.  We want a build failure if it's misconfigured.
+  //
+  test("Attribute defaults should validate against the schema!") {
+    defaultsSchema.newValidator.validate(new StreamSource(getClass.getResource("/xsl/defaults.xml").toString))
+  }
+
+  test("If there's a namespace in attribute defaults, it should be reflected in the XSL") {
+    val defaultMap = new File("src/test/resources/tests/mapping-tests/defaults/maps/defaults.xml")
+    val attributeDefaults = new File("src/test/resources/defaults-ns.xml")
+
+    var docBuilder : DocumentBuilder = null
+    var outDoc : Document = null
+    try {
+      docBuilder = borrowParser
+      outDoc = docBuilder.newDocument
+    } finally {
+      if (docBuilder != null) returnParser(docBuilder)
+    }
+
+    val xslDest = new DOMDestination(outDoc)
+
+    val mapperTrans = AttributeMapper.getXsltTransformer (mapperXsltExec, Map[QName, XdmValue]
+      (new QName("defaults-config")->new XdmAtomicValue(attributeDefaults.toURI.toString())))
+
+    mapperTrans.setSource(new StreamSource(defaultMap))
+    mapperTrans.setDestination(xslDest)
+    mapperTrans.transform()
+
+    val fooExpressionStr = "namespace-uri-for-prefix('foo',/element()[1])"
+    val xExpressionStr = "namespace-uri-for-prefix('x',/element()[1])"
+
+    var fooExpression : XPathExpression = null
+    var xExpression : XPathExpression = null
+
+    try {
+      fooExpression = borrowExpression(fooExpressionStr, NS_CONTEXT, XPATH_VERSION)
+      xExpression = borrowExpression(xExpressionStr, NS_CONTEXT, XPATH_VERSION)
+
+      assert(fooExpression.evaluate(outDoc, XPathConstants.STRING).asInstanceOf[String] == "bar")
+      assert(xExpression.evaluate(outDoc, XPathConstants.STRING).asInstanceOf[String] == "yz")
+    }  finally {
+      if (fooExpression != null) returnExpression(fooExpressionStr, NS_CONTEXT, XPATH_VERSION, fooExpression)
+      if (xExpression != null) returnExpression(xExpressionStr, NS_CONTEXT, XPATH_VERSION, xExpression)
+    }
+  }
+}


### PR DESCRIPTION
Before this change {D} would get a value from the single location --
the location that identity searches for a value by default.  This
change allows {D} to search several places for a default
value. Additionally the search is specified via configuration
(defaults.xml) so changes to the search logic can be easily made.

Values can be searched via XPath, by SAML Attribute name, or default
values can be set directly by passing in parameters.