### PR TITLE
Support `groups` as a standard attribute.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,9 @@
 # Releases #
 ## In Progress Work ##
-1. Disallowing inline functions in policy path expressions.
+1. Disallow inline functions in policy path expressions.
 1. Fixed a bug where multi-value attributes were not always returned as an array when generating JSON output.
+1. We now support `groups` as a standard attribute, which supports default value with {D}
+   1. As a result of the change, standard attributes will no longer be set in the SAML assertion if they are not specified in the mapping policy.
 
 ## Release 2.0.1 (2017-09-28) ##
 1. Fixed a number of parsing bugs when using {(P|A)ts?()} in a template that spans multiple lines.

--- a/core/src/main/resources/xq/mapping2JSON.xq
+++ b/core/src/main/resources/xq/mapping2JSON.xq
@@ -12,6 +12,7 @@ declare option output:indent "yes";
 
 declare variable $matchMarker as xs:string := "{Pts((:-))}";
 declare variable $knownPrefixes as xs:string* := ('saml2p','saml2','xs','xsi','mapping','xml','');
+declare variable $multiValueDefaultAttributes as xs:string* := ('roles', 'groups');
 
 declare function mapping:convertAttributeValue($name as xs:string, $in as xs:string, $flags as xs:string*) as xs:anyAtomicType? {
   let $retValue := if ($in = '') then () else replace($in,'&#xA0;',' ')
@@ -55,7 +56,7 @@ declare function mapping:convertLocalGroup($local as element()) as map(*) {
   let $elems := $local/element()
   return map:merge(for $elem in $elems return map:entry(mapping:local-name($elem),
   let $multiAttribs := (
-    if ((mapping:local-name($elem) = 'roles') and (mapping:local-name($elem/..) = 'user')) then "value" else (),
+    if ((mapping:local-name($elem) = $multiValueDefaultAttributes) and (mapping:local-name($elem/..) = 'user')) then "value" else (),
       if (exists($elem/@multiValue) and xs:boolean($elem/@multiValue)) then "value" else ())
         return if ($elem/@*[name(.) = ('type','multiValue')]) then mapping:convertAttributeMap($elem, $multiAttribs, ('name'), ('multiValue')) else
           if ($multiAttribs) then mapping:convertAttributeList (mapping:local-name($elem), string($elem/@value), ('multiValue')) else

--- a/core/src/main/resources/xq/mapping2XML.xq
+++ b/core/src/main/resources/xq/mapping2XML.xq
@@ -16,7 +16,8 @@ declare option output:indent "yes";
 (: declare variable $__JSON__ external; :)
 declare variable $__JSON__ external;
 declare variable $policyJSON := parse-json($__JSON__);
-declare variable $defaultAttributes as xs:string* := ('name','email','expire','domain','roles');
+declare variable $multiValueDefaultAttributes as xs:string* := ('roles', 'groups');
+declare variable $defaultAttributes as xs:string* := ('name','email','expire','domain', $multiValueDefaultAttributes);
 declare variable $remoteMultiValues as xs:string* := ('whitelist','blacklist','notAnyOf','anyOneOf');
 
 declare function mapping:convertMatchValue($in as xs:string) as xs:string {
@@ -72,7 +73,7 @@ declare function mapping:convertLocalGroup($localGroupName as xs:string, $localG
 declare function mapping:convertLocalAttribute($attribName as xs:string, $attribValue as item(), $userGroup as xs:boolean) as element() {
   let $multiValues as xs:string* :=
     (
-    if ($userGroup and ($attribName="roles")) then "value" else (),
+    if ($userGroup and ($attribName=$multiValueDefaultAttributes)) then "value" else (),
       typeswitch ($attribValue)
         case $o as map(*) return if (map:contains($o, "multiValue") and $o?multiValue) then "value" else ()
         case $a as array(*) return "value"

--- a/core/src/main/resources/xsd/defaults.xsd
+++ b/core/src/main/resources/xsd/defaults.xsd
@@ -13,9 +13,9 @@
             <xs:element name="attribute" type="mapping:AttributeDefaultDef" minOccurs="1"
                 maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:assert test="every $att in ('name','email','domain','expire', 'roles') satisfies mapping:attribute[@name=$att]"
-                   saxon:message="Every standard attribute (name, email, domain, expire, and roles) must have a default"
-                   xerces:message="Every standard attribute (name, email, domain, expire, and roles) must have a default"
+        <xs:assert test="every $att in ('name','email','domain','expire', 'roles', 'groups') satisfies mapping:attribute[@name=$att]"
+                   saxon:message="Every standard attribute (name, email, domain, expire, roles, and groups) must have a default"
+                   xerces:message="Every standard attribute (name, email, domain, expire, roles, and groups) must have a default"
                    />
         <xs:assert test="count(mapping:attribute/@name) = count(distinct-values(mapping:attribute/@name))"
                    saxon:message="Attributes should not be listed more than once"
@@ -70,6 +70,7 @@
             <xs:enumeration value="email"/>
             <xs:enumeration value="domain"/>
             <xs:enumeration value="roles"/>
+            <xs:enumeration value="groups"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/core/src/main/resources/xsd/mapping.xsd
+++ b/core/src/main/resources/xsd/mapping.xsd
@@ -68,6 +68,7 @@
                     <xs:element name="domain" type="mapping:DefaultSingleLocalString" minOccurs="0"/>
                     <xs:element name="expire" type="mapping:DefaultSingleLocalDateTime" minOccurs="0"/>
                     <xs:element name="roles" type="mapping:DefaultSingleLocalStrings" minOccurs="0"/>
+                    <xs:element name="groups" type="mapping:DefaultSingleLocalStrings" minOccurs="0"/>
                 </xs:all>
             </xs:extension>
         </xs:complexContent>

--- a/core/src/main/resources/xsl/defaults.xml
+++ b/core/src/main/resources/xsl/defaults.xml
@@ -88,4 +88,8 @@
     <attribute name="roles" multiValue="true">
         <location saml-attribute="roles"/>
     </attribute>
+
+    <attribute name="groups" multiValue="true">
+        <location saml-attribute="groups"/>
+    </attribute>
 </attribute-defaults>

--- a/core/src/test/resources/tests/include/defaults-asserts.xml
+++ b/core/src/test/resources/tests/include/defaults-asserts.xml
@@ -28,6 +28,11 @@
             There should be a single nova:admin attribute
         </assert>
     </assert-group>
+    <assert-group name="groups">
+        <assert test="empty(mapping:get-attributes('groups'))">
+            There should not be any groups assigned.
+        </assert>
+    </assert-group>
     <assert-group name="email">
         <assert test="mapping:get-attribute('email') = 'no-reply@rackspace.com'">
             The email should be no-reply@rackspace.com

--- a/core/src/test/resources/tests/mapping-tests/defaults-groups/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-groups/asserts/sample_assert.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#email?>
+
+<!-- The groups group1, group2, and other_group should be set -->
+<?assert every $g in ('group1', 'group2', 'other_group') satisfies $g=mapping:get-attributes('groups')?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group1</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group2</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">other_group</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults-sj.json
+++ b/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults-sj.json
@@ -1,0 +1,19 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "local": {
+          "user": {
+            "domain":"{D}",
+            "name":"{D}",
+            "email":"{D}",
+            "roles": "{D}",
+            "groups": "{D}",
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults-sj.yaml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults-sj.yaml
@@ -1,0 +1,12 @@
+---
+mapping:
+  rules:
+  - local:
+      user:
+        domain: "{D}"
+        name: "{D}"
+        email: "{D}"
+        roles: "{D}"
+        groups: "{D}"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults.json
+++ b/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults.json
@@ -1,0 +1,19 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "local": {
+          "user": {
+            "domain":"{D}",
+            "name":"{D}",
+            "email":"{D}",
+            "roles": ["{D}"],
+            "groups": ["{D}"],
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="{D}"/>
+               <roles value="{D}"/>
+               <groups value="{D}"/>
+            </user>
+         </local>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults.yaml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-groups/maps/defaults.yaml
@@ -1,0 +1,14 @@
+---
+mapping:
+  rules:
+  - local:
+      user:
+        domain: "{D}"
+        name: "{D}"
+        email: "{D}"
+        roles:
+          - "{D}"
+        groups:
+          - "{D}"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/mapping-tests/defaults-noroles/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-noroles/asserts/sample_assert.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+
+<!-- Roles should not be set -->
+<?assert empty(mapping:get-attributes('roles'))?>
+
+<!-- The groups group1, group2, and other_group should be set -->
+<?assert every $g in ('group1', 'group2', 'other_group') satisfies $g=mapping:get-attributes('groups')?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <!--
+            Set this here to ensure we don't pass roles if they are
+            not specified in the policy.
+        -->
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group1</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group2</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">other_group</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults-sj.json
+++ b/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults-sj.json
@@ -1,0 +1,18 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "local": {
+          "user": {
+            "domain":"{D}",
+            "name":"{D}",
+            "email":"{D}",
+            "groups": "{D}",
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults-sj.yaml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults-sj.yaml
@@ -1,0 +1,11 @@
+---
+mapping:
+  rules:
+  - local:
+      user:
+        domain: "{D}"
+        name: "{D}"
+        email: "{D}"
+        groups: "{D}"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults.json
+++ b/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults.json
@@ -1,0 +1,18 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "local": {
+          "user": {
+            "domain":"{D}",
+            "name":"{D}",
+            "email":"{D}",
+            "groups": ["{D}"],
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="{D}"/>
+               <groups value="{D}"/>
+            </user>
+         </local>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults.yaml
+++ b/core/src/test/resources/tests/mapping-tests/defaults-noroles/maps/defaults.yaml
@@ -1,0 +1,12 @@
+---
+mapping:
+  rules:
+  - local:
+      user:
+        domain: "{D}"
+        name: "{D}"
+        email: "{D}"
+        groups:
+          - "{D}"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email2.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email2.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The email should be no-foo@rackspace.com -->
 <?assert mapping:get-attribute('email') = 'no-foo@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email3.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email3.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The email should be no-foo@rackspace.com -->
 <?assert mapping:get-attribute('email') = 'no-foo@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email4.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-email4.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The email should be no-foo@rackspace.com -->
 <?assert mapping:get-attribute('email') = 'no-foo@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire1.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire1.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- Expire should pick date from conditions -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2013-11-17T16:18:06.298Z'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire2.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire2.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- Expire should pick date from AuthNStatement -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2013-11-17T16:17:06.298Z'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire3.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire3.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- Expire should pick date from Subject -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2012-11-17T16:19:06.298Z'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire4.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire4.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- Expire should pick date from Subject, in the 2nd assertion! -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData/@NotOnOrAfter = '2011-11-17T16:19:06.298Z'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire5.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-expire5.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- If no dates are given the expire should be no longer than 15 mins in the future  -->
 <?assert (mapping:get-expire() - current-dateTime()) <= xs:dayTimeDuration('PT15M')?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name1.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name1.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- If nameId is missing use email address instead of name -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-reply@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name2.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name2.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- If nameId is missing prefer claim name over email -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-foo-2@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name3.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-name3.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- If naimeId is missing prefer claim name over urn:oid:1.3.6.1.4.1.5923.1.1.1.6 -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:Subject/saml2:NameID =  'no-foo-2@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-nodomain.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert-nodomain.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#email?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The param value should be input for the domain -->
 <?assert mapping:get-attribute('domain') = 'foo:999-882'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults/asserts/sample_assert.xml
@@ -37,6 +37,18 @@
             <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:type="xs:string">nova:admin</saml2:AttributeValue>
         </saml2:Attribute>
+        <!--
+            This is actually testing that groups should not be copied
+            over, if they are not specified in the policy.
+        -->
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group1</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group2</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">other_group</saml2:AttributeValue>
+        </saml2:Attribute>
         <saml2:Attribute Name="domain">
             <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:type="xs:string">323676</saml2:AttributeValue>

--- a/core/src/test/resources/tests/mapping-tests/defaults2/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults2/asserts/sample_assert.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The email should be no-reply@rackspace.com -->
 <?assert mapping:get-attribute('email') = 'john.doe@rackspace.com'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults3/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults3/asserts/sample_assert.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The email should be  john.doe &lt;john.doe@323676.rackspace.com&gt; -->
 <?assert mapping:get-attribute('email') = 'john.doe <john.doe@323676.rackspace.com>'?>

--- a/core/src/test/resources/tests/mapping-tests/defaults4/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/defaults4/asserts/sample_assert.xml
@@ -9,6 +9,7 @@
 <?include ../../../include/defaults-asserts.xml#expire?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#roles?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The email should be  John Doe &lt;john.doe@323676.rackspace.com&gt; -->
 <?assert mapping:get-attribute('email') = 'John Doe <john.doe@323676.rackspace.com>'?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-exp/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-exp/asserts/sample_assert.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- The message should expire in the future -->
 <?assert mapping:get-expire() > current-dateTime()?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/asserts/sample_assert.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- include common and default asserts -->
+<?include ../../../include/common-asserts.xml?>
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+
+<!-- Roles should be empty -->
+<?assert empty(mapping:get-attributes('roles'))?>
+
+<!-- There should be 2 groups -->
+<?assert count(mapping:get-attributes('groups')) = 2?>
+
+<!-- Only rackspace-.* groups should match -->
+<?assert every $g in ('rackspace-adminUsers','rackspace-observers') satisfies $g=mapping:get-attributes('groups') ?>
+
+<!-- None of the non-whitelisted groups should be returned  -->
+<?assert every $g in mapping:get-attributes('groups') satisfies not($g = ('nova:observer', 'nova:admin'))?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">rackspace-adminUsers</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:observer</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">rackspace-observers</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/asserts/sample_assert2.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- include common and default asserts -->
+<?include ../../../include/common-asserts.xml?>
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+
+<!-- Roles should be empty -->
+<?assert empty(mapping:get-attributes('roles'))?>
+
+<!-- There should be 2 groups -->
+<?assert count(mapping:get-attributes('groups')) = 4?>
+
+<!-- Only rackspace-.* groups should match -->
+<?assert every $g in ('rackspace-adminUsers','rackspace-observers','rackspace-foo', 'rackspace-bar')
+         satisfies $g=mapping:get-attributes('groups') ?>
+
+<!-- None of the non-whitelisted groups should be returned  -->
+<?assert every $g in mapping:get-attributes('groups') satisfies not($g = ('nova:observer', 'nova:admin'))?>
+
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">rackspace-adminUsers</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:observer</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">rackspace-observers</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">rackspace-foo</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">rackspace-bar</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/asserts/sample_assert3.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/asserts/sample_assert3.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- include common and default asserts -->
+<?include ../../../include/common-asserts.xml?>
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#email?>
+
+
+<!-- There should be no roles -->
+<?assert count(mapping:get-attributes('roles')) = 0?>
+
+<!-- There should be no groups -->
+<?assert count(mapping:get-attributes('groups')) = 0?>
+
+
+<!-- None of the groups that don't match the whitelist should be returend -->
+<?assert every $r in mapping:get-attributes('groups') satisfies not($r = ('nova:observer', 'nova:admin','nova:foo','nova:bar'))?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:observer</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:foo</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">nova:bar</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3-2.json
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3-2.json
@@ -1,0 +1,27 @@
+{
+  "mapping" : {
+      "rules": [
+          {
+              "remote": [
+                  {
+                      "name":"groups",
+                      "regex":true,
+                      "multiValue":true,
+                      "whitelist": ["rackspace-.*"]
+                  }
+              ],
+              "local": {
+                  "user": {
+                      "domain":"{D}",
+                      "name":"{D}",
+                      "email":"{D}",
+                      "roles":"{D}",
+                      "expire":"{D}",
+                      "groups":"{0}"
+                  }
+              }
+          }
+      ],
+      "version" : "RAX-1"
+  }
+ }

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3-2.yaml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3-2.yaml
@@ -1,0 +1,18 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: groups
+      regex: true
+      multiValue: true
+      whitelist:
+      - rackspace-.*
+    local:
+      user:
+        domain: "{D}"
+        name: "{D}"
+        email: "{D}"
+        roles: "{D}"
+        expire: "{D}"
+        groups: "{0}"
+  version: RAX-1

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3.json
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3.json
@@ -1,0 +1,27 @@
+{
+  "mapping" : {
+      "rules": [
+          {
+              "remote": [
+                  {
+                      "name":"groups",
+                      "regex":true,
+                      "multiValue":true,
+                      "whitelist": ["rackspace-.*"]
+                  }
+              ],
+              "local": {
+                  "user": {
+                      "domain":"{D}",
+                      "name":"{D}",
+                      "email":"{D}",
+                      "roles": ["{D}"],
+                      "expire":"{D}",
+                      "groups": ["{0}"]
+                  }
+              }
+          }
+      ],
+      "version" : "RAX-1"
+  }
+}

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="{D}"/>
+               <roles value="{D}"/>
+               <groups value="{0}"/>
+            </user>
+         </local>
+        <remote>
+            <attribute multiValue="true" name="groups" whitelist="rackspace-.*" regex="true"/>
+        </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3.yaml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-group/maps/mapping-rule-list3.yaml
@@ -1,0 +1,20 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: groups
+      regex: true
+      multiValue: true
+      whitelist:
+      - rackspace-.*
+    local:
+      user:
+        domain: "{D}"
+        name: "{D}"
+        email: "{D}"
+        roles:
+          - "{D}"
+        expire: "{D}"
+        groups:
+          - "{0}"
+  version: RAX-1

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list/asserts/sample_assert.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 
 <!-- There should be 4 roles -->

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list/asserts/sample_assert2.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 4 roles -->
 <?assert count(mapping:get-attributes('roles')) = 1?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list/asserts/sample_assert3.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list/asserts/sample_assert3.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 4 roles -->
 <?assert count(mapping:get-attributes('roles')) = 0?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list2/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list2/asserts/sample_assert.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 3 roles -->
 <?assert count(mapping:get-attributes('roles')) = 3?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list2/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list2/asserts/sample_assert2.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 3 roles -->
 <?assert count(mapping:get-attributes('roles')) = 3?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list2/asserts/sample_assert3.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list2/asserts/sample_assert3.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be no roles -->
 <?assert count(mapping:get-attributes('roles')) = 0?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list3/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list3/asserts/sample_assert.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 2 roles -->
 <?assert count(mapping:get-attributes('roles')) = 2?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list3/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list3/asserts/sample_assert2.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 4 roles -->
 <?assert count(mapping:get-attributes('roles')) = 4?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list3/asserts/sample_assert3.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list3/asserts/sample_assert3.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be no roles -->
 <?assert count(mapping:get-attributes('roles')) = 0?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list4/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list4/asserts/sample_assert.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should 4 roles total -->
 <?assert count(mapping:get-attributes('roles')) = 4 ?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-list4/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-list4/asserts/sample_assert2.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should 6 roles total -->
 <?assert count(mapping:get-attributes('roles')) = 8 ?>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule/asserts/sample_assert2.xml
@@ -7,6 +7,7 @@
 <?include ../../../include/defaults-asserts.xml#name?>
 <?include ../../../include/defaults-asserts.xml#domain?>
 <?include ../../../include/defaults-asserts.xml#email?>
+<?include ../../../include/defaults-asserts.xml#groups?>
 
 <!-- There should be 2 roles -->
 <?assert count(mapping:get-attributes('roles')) = 2?>


### PR DESCRIPTION
This means that groups can have a valid default value : {D}
...and that is passed in SAML as `groups` instead of `user/groups`

As a result of the change, standard attributes will no longer be set
in the SAML assertion if they are not specified in the mapping policy.