### PR TITLE
Set mapping:multiValue in a SAML attribute

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 1. Fixed a bug where multi-value attributes were not always returned as an array when generating JSON output.
 1. We now support `groups` as a standard attribute, which supports default value with {D}
    1. As a result of the change, standard attributes will no longer be set in the SAML assertion if they are not specified in the mapping policy.
+1. We now set `mapping:multiValue` in a SAML attribute to denote whether the attribute may hold several values.
+   1. Setting `mapping:multiValue` helps in conversion to JSON when setting extended attributes via the `RAX-AUTH:extendedAttributes`.
 
 ## Release 2.0.1 (2017-09-28) ##
 1. Fixed a number of parsing bugs when using {(P|A)ts?()} in a template that spans multiple lines.

--- a/core/src/main/resources/xq/ext2JSON.xq
+++ b/core/src/main/resources/xq/ext2JSON.xq
@@ -29,8 +29,9 @@ declare option output:method "json";
 declare option output:indent "yes";
 
 declare function auth:addAttributeValues ($a as element()) as item() {
-  let $values := for $v in $a/auth:value return string($v)
-    return if (count($values) = 1) then $values[1] else array {$values}
+  let $values := for $v in $a/auth:value return string($v),
+      $multiValue := if (exists($a/@multiValue)) then xs:boolean($a/@multiValue) else false()
+    return if ($multiValue) then array {$values} else $values[1]
 };
 
 declare function auth:addAttributes ($g as element()) as map(*) {

--- a/core/src/main/resources/xsd/extAttribs.xsd
+++ b/core/src/main/resources/xsd/extAttribs.xsd
@@ -23,5 +23,6 @@
             <xs:element name="value" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="multiValue" type="xs:boolean" use="optional"/>
     </xs:complexType>
 </xs:schema>

--- a/core/src/main/resources/xsl/mapping.xsl
+++ b/core/src/main/resources/xsl/mapping.xsl
@@ -112,6 +112,7 @@
                     <xslout:otherwise>
                         <saml2:Attribute>
                             <xslout:attribute name="Name" select="$attribName"/>
+                            <xslout:attribute name="mapping:multiValue" select="$isMultiValue"/>
                             <xslout:for-each select="$attribValues">
                                 <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                                     <xslout:choose>

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion-merge.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion-merge.xml
@@ -44,21 +44,21 @@
          <saml2:Attribute Name="roles">
             <saml2:AttributeValue xsi:type="xs:string">nova:admin</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="user/foo">
+         <saml2:Attribute Name="user/foo" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:dateTime">2017-01-04T14:41:42.206-06:00</saml2:AttributeValue>
              <saml2:AttributeValue xsi:type="xs:dateTime">2018-01-04T14:41:42.206-06:00</saml2:AttributeValue>
          </saml2:Attribute>
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
-         <saml2:Attribute Name="faws/policy">
+         <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!</saml2:AttributeValue>
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
          </saml2:Attribute>
-          <saml2:Attribute Name="faws/policy2">
+          <saml2:Attribute Name="faws/policy2" mapping:multiValue="true">
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!</saml2:AttributeValue>

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion-single.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion-single.xml
@@ -2,7 +2,7 @@
 
 <!-- defualt extn sssertions apply -->
 
-<?include ../include/defaults-extn.xml?>
+<?include ../include/single-faws-extn.xml?>
 
 <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -45,20 +45,14 @@
             <saml2:AttributeValue xsi:type="xs:string">nova:admin</saml2:AttributeValue>
          </saml2:Attribute>
          <saml2:Attribute Name="user/foo" mapping:multiValue="true">
-            <saml2:AttributeValue xsi:type="xs:dateTime">2017-01-04T14:41:42.206-06:00</saml2:AttributeValue>
+             <saml2:AttributeValue xsi:type="xs:dateTime">2017-01-04T14:41:42.206-06:00</saml2:AttributeValue>
+             <saml2:AttributeValue xsi:type="xs:dateTime">2018-01-04T14:41:42.206-06:00</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="user/foo" mapping:multiValue="true">
-              <saml2:AttributeValue xsi:type="xs:dateTime">2018-01-04T14:41:42.206-06:00</saml2:AttributeValue>
-          </saml2:Attribute>
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
          <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
-            <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
-            <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!</saml2:AttributeValue>
-            <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
-            <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
          </saml2:Attribute>
           <saml2:Attribute Name="faws/policy2" mapping:multiValue="true">
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion-split.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion-split.xml
@@ -44,34 +44,34 @@
          <saml2:Attribute Name="roles">
             <saml2:AttributeValue xsi:type="xs:string">nova:admin</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="user/foo">
+         <saml2:Attribute Name="user/foo" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:dateTime">2017-01-04T14:41:42.206-06:00</saml2:AttributeValue>
              <saml2:AttributeValue xsi:type="xs:dateTime">2018-01-04T14:41:42.206-06:00</saml2:AttributeValue>
          </saml2:Attribute>
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
-         <saml2:Attribute Name="faws/policy">
+         <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="faws/policy">
+         <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="faws/policy">
+         <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="faws/policy">
+         <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
          </saml2:Attribute>
-         <saml2:Attribute Name="faws/policy">
+         <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
          </saml2:Attribute>
-          <saml2:Attribute Name="faws/policy2">
+          <saml2:Attribute Name="faws/policy2" mapping:multiValue="true">
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!</saml2:AttributeValue>
           </saml2:Attribute>
-          <saml2:Attribute Name="faws/policy2">
+          <saml2:Attribute Name="faws/policy2" mapping:multiValue="true">
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
           </saml2:Attribute>

--- a/core/src/test/resources/tests/include/single-faws-extn.xml
+++ b/core/src/test/resources/tests/include/single-faws-extn.xml
@@ -1,0 +1,92 @@
+<!--
+    Assertions used to test extracting extensions. In this case there
+    should be a single FAWSPolicy value.
+-->
+
+<common-assertions xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <assert-group name="xml">
+        <assert test="/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='foo']">
+            There should be a user group with foo attribute.
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='foo']/auth:value) = 2">
+            There should be two values for attribute foo
+        </assert>
+        <assert test="every $v in /auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='foo']/auth:value satisfies $v=('2017-01-04T14:41:42.206-06:00',
+                      '2018-01-04T14:41:42.206-06:00')">
+            The values should match correctly.
+        </assert>
+        <assert test="/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='bar']">
+            There should be a user group with bar attribute
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='bar']/auth:value) = 1">
+            There should be a single value for attribute bar
+        </assert>
+        <assert test="every $v in /auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='bar']/auth:value satisfies $v=('bar')">
+            The value should match correctly.
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute) = 2">
+            There should only be two attributes in user
+        </assert>
+        <assert test="/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy']">
+            There should be a faws group with policy attribute
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy']/auth:value) = 1">
+            There should be 1 value for attribute policy
+        </assert>
+        <assert test="every $v in /auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy']/auth:value satisfies $v=
+                      ('AWSPolicy')">
+            The value should match correctly
+        </assert>
+        <assert test="/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy2']">
+            There should be a faws group with policy2 attribute
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy2']/auth:value) = 5">
+            There should be 5 values for attribute policy2
+        </assert>
+        <assert test="every $v in /auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy2']/auth:value satisfies $v=
+                      ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!','AWSPolicy3','AWSPolicy YEA!!')">
+            The values should match correctly
+        </assert>
+    </assert-group>
+    <assert-group name="json">
+        <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?user?foo)'>
+            There should be a user group with foo attribute
+        </json-assert>
+        <json-assert test='count($_?("RAX-AUTH:extendedAttributes")?user?foo?*) = 2'>
+            There should be two values for attribute foo
+        </json-assert>
+        <json-assert test="every $val in $_?('RAX-AUTH:extendedAttributes')?user?foo?* satisfies $val=('2017-01-04T14:41:42.206-06:00',
+                           '2018-01-04T14:41:42.206-06:00')">
+            The values should match correctly.
+        </json-assert>
+        <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?user?bar)'>
+            There should be a user group with bar attribute
+        </json-assert>
+        <json-assert test="$_?('RAX-AUTH:extendedAttributes')?user?bar = 'bar'">
+            The value of bar should be bar
+        </json-assert>
+        <json-assert test='count($_?("RAX-AUTH:extendedAttributes")?user?*) = 2'>
+            There should only be 2 attributes in user
+        </json-assert>
+        <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?faws?policy)'>
+            There should be a user faws with policy attribute
+        </json-assert>
+        <json-assert test='count($_?("RAX-AUTH:extendedAttributes")?faws?policy?*) = 1'>
+            There should be 1 value for attribute policy
+        </json-assert>
+        <json-assert test="every $val in $_?('RAX-AUTH:extendedAttributes')?faws?policy?* satisfies $val=
+                           ('AWSPolicy')">
+            The value should match correctly
+        </json-assert>
+        <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?faws?policy2)'>
+            There should be a user faws with policy2 attribute
+        </json-assert>
+        <json-assert test='count($_?("RAX-AUTH:extendedAttributes")?faws?policy2?*) = 5'>
+            There should be 5 values for attribute policy2
+        </json-assert>
+        <json-assert test="every $val in $_?('RAX-AUTH:extendedAttributes')?faws?policy2?* satisfies $val=
+                           ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!','AWSPolicy3','AWSPolicy YEA!!')">
+            The values should match correctly
+        </json-assert>
+    </assert-group>
+</common-assertions>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
@@ -12,7 +12,7 @@
 <!-- Ensure that faws/observers is setup correctly -->
 <?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
 
-<!-- Ensure that faws/admins is set to multivalue -->
+<!-- Ensure that faws/observers is set to multivalue -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/@mapping:multiValue = 'true'?>
 
 

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
@@ -12,6 +12,10 @@
 <!-- Ensure that faws/observers is setup correctly -->
 <?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
 
+<!-- Ensure that faws/admins is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/@mapping:multiValue = 'true'?>
+
+
 <!-- Ensure that faws/nones is not set -->
 <?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones'])?>
 

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert.xml
@@ -12,8 +12,15 @@
 <!-- Ensure that faws/admins is set correctly -->
 <?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
 
+<!-- Ensure that faws/admins is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins']/@mapping:multiValue = 'true'?>
+
 <!-- Ensure that faws/observers is setup correctly -->
 <?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
+
+<!-- Ensure that faws/observers is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/@mapping:multiValue = 'true'?>
+
 
 <!-- Ensure that faws/nones is not set -->
 <?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones'])?>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
@@ -12,6 +12,10 @@
 <!-- Ensure that faws/nones is setup correctly -->
 <?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
 
+<!-- Ensure that faws/admins is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/@mapping:multiValue = 'true'?>
+
+
 <!-- Ensure that faws/observers is not set -->
 <?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers'])?>
 

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
@@ -12,7 +12,7 @@
 <!-- Ensure that faws/nones is setup correctly -->
 <?assert every $r in /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/saml2:AttributeValue satisfies $r=('12285/AWSPolicy','38839/AWSPolicy')?>
 
-<!-- Ensure that faws/admins is set to multivalue -->
+<!-- Ensure that faws/nones is set to multivalue -->
 <?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/@mapping:multiValue = 'true'?>
 
 

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext2/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext2/asserts/sample_assert.xml
@@ -12,11 +12,24 @@
 <!-- faws/canAddAWSAccount should be true-->
 <?assert mapping:get-attributes('faws/canAddAWSAccount') = 'true'?>
 
+<!-- ensure faws/canAddAWSAccount is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/canAddAWSAccount']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/canAddAWSAccount']/@mapping:multiValue='false'
+?>
+
 <!-- faws/991049284483 should contain correct values -->
 <?assert every $r in ('fanatical_aws:admin','AdminstratorAccess') satisfies $r=mapping:get-attributes('faws/991049284483')?>
 
+<!-- Ensure that faws/991049284483 is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/991049284483']/@mapping:multiValue = 'true'?>
+
+
 <!-- faws/042423532529 should contain correct values  -->
 <?assert every $r in ('fanatical_aws:observer','RackspaceReadOnly') satisfies $r=mapping:get-attributes('faws/042423532529')?>
+
+<!-- Ensure that faws/042423532529 is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/042423532529']/@mapping:multiValue = 'true'?>
+
 
 <samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
     Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute/asserts/sample_assert.xml
@@ -7,11 +7,22 @@
 <!-- There should be an extended user attribute foo with the value bar -->
 <?assert mapping:get-attribute('user/foo') = 'BAR!'?>
 
+<!-- Ensure that user/foo is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue='false'
+?>
+
 <!-- There should be an extended faws attribute named policy and the value should be AWSPolicy -->
 <?assert mapping:get-attribute('faws/policy') = 'AWSPolicy'?>
 
 <!-- faws/policy should only contain a single value -->
 <?assert count(mapping:get-attributes('faws/policy')) = 1 ?>
+
+<!-- Ensure that faws/policy is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue='false'
+?>
+
 
 <saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute/asserts/sample_assert2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute/asserts/sample_assert2.xml
@@ -7,11 +7,22 @@
 <!-- There should be an extended user attribute foo with the value bar -->
 <?assert mapping:get-attribute('user/foo') = 'FOO?'?>
 
+<!-- Ensure that user/foo is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue='false'
+?>
+
 <!-- There should be an extended faws attribute named policy and the value should be AWSPolicy -->
 <?assert mapping:get-attribute('faws/policy') = 'AWSPolicy'?>
 
 <!-- faws/policy should only contain a single value -->
 <?assert count(mapping:get-attributes('faws/policy')) = 1 ?>
+
+<!-- Ensure that faws/policy is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue='false'
+?>
+
 
 <saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute2/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute2/asserts/sample_assert.xml
@@ -10,11 +10,20 @@
 <!-- The extended attribute foo should contain a date no longer than 2 hours in the future -->
 <?assert (xs:dateTime(mapping:get-attribute('user/foo')) - current-dateTime()) <= xs:dayTimeDuration('PT2H')?>
 
+<!-- Ensure that user/foo is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue='false'
+?>
+
 <!-- There should exist 5 FAWS policies -->
 <?assert count(mapping:get-attributes('faws/policy')) = 5 ?>
 
 <!-- The expressed FAWS policies should be returned -->
 <?assert every $p in ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!', 'AWSPolicy3', 'AWSPolicy YEA!!') satisfies $p=mapping:get-attributes('faws/policy')?>
+
+<!-- Ensure that faws/policy is set to multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue = 'true'?>
+
 
 <saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute3/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute3/asserts/sample_assert.xml
@@ -10,11 +10,22 @@
 <!-- The extended attribute foo should contain a date no longer than 2 hours in the future -->
 <?assert (xs:dateTime(mapping:get-attribute('user/foo')) - current-dateTime()) <= xs:dayTimeDuration('PT2H')?>
 
+<!-- Ensure that user/foo is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue='false'
+?>
+
 <!-- There should exist 1 FAWS policies -->
 <?assert count(mapping:get-attributes('faws/policy')) = 1 ?>
 
 <!-- The expressed FAWS policies should be returned -->
 <?assert 'AWSPolicy'=mapping:get-attributes('faws/policy')?>
+
+<!-- Ensure that faws/policy is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue='false'
+?>
+
 
 <saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute4/asserts/sample_assert.xml
@@ -10,6 +10,11 @@
 <!-- The extended attribute foo should contain a date no longer than 2 hours in the future -->
 <?assert (xs:dateTime(mapping:get-attribute('user/foo')) - current-dateTime()) <= xs:dayTimeDuration('PT2H')?>
 
+<!-- Ensure that faws/policy is not multiValue -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue) or
+         /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/@mapping:multiValue='false'
+?>
+
 <!-- There should exist 0 FAWS policies -->
 <?assert count(mapping:get-attributes('faws/policy')) = 0 ?>
 


### PR DESCRIPTION
Revisions to address PR comments in #57.

Addressed:

1. Rebased onto `master` to fix the release notes conflict.
1. Fixed some test comments.

Did Not Address:

1. Default boolean value in `extAttribs.xsd`.