### PR TITLE
An empty extended attribute is now always displayed in RAX-AUTH:extendedAttributes.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,8 @@
 1. Clean up: Improve extended attributes in XML.
    1. Denote that `multiValue` attribute is `false` if not specifed.
    1. Ensure that SAML and internal namespaces don't leak into the `RAX-AUTH:extendedAttributes` element.
+1. An empty extended attribute is now represented as having a `null` value (or an empty array) in `RAX-AUTH:extendedAttributes` in JSON.
+   1. The previous behavior was to not output an extended attribute at all if it was empty.
 
 ## Release 2.1.1 (2017-10-24) ##
 1. Updated Dependency

--- a/core/src/main/resources/xq/ext2JSON.xq
+++ b/core/src/main/resources/xq/ext2JSON.xq
@@ -28,7 +28,7 @@ declare namespace auth = "http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1
 declare option output:method "json";
 declare option output:indent "yes";
 
-declare function auth:addAttributeValues ($a as element()) as item() {
+declare function auth:addAttributeValues ($a as element()) as item()? {
   let $values := for $v in $a/auth:value return string($v),
       $multiValue := if (exists($a/@multiValue)) then xs:boolean($a/@multiValue) else false()
     return if ($multiValue) then array {$values} else $values[1]

--- a/core/src/main/resources/xsd/extAttribs.xsd
+++ b/core/src/main/resources/xsd/extAttribs.xsd
@@ -20,7 +20,7 @@
 
     <xs:complexType name="Attribute">
         <xs:sequence>
-            <xs:element name="value" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="multiValue" type="xs:boolean"

--- a/core/src/main/resources/xsl/mapping.xsl
+++ b/core/src/main/resources/xsl/mapping.xsl
@@ -114,17 +114,19 @@
                             <xslout:attribute name="Name" select="$attribName"/>
                             <xslout:attribute name="mapping:multiValue" select="$isMultiValue"/>
                             <xslout:for-each select="$attribValues">
-                                <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                                    <xslout:choose>
-                                        <xslout:when test="exists($type)">
-                                            <xslout:attribute name="xsi:type" select="$type"/>
-                                        </xslout:when>
-                                        <xslout:otherwise>
-                                            <xslout:attribute name="xsi:type">xs:string</xslout:attribute>
-                                        </xslout:otherwise>
-                                    </xslout:choose>
-                                    <xslout:value-of select="mapping:transformNBSP(.)"/>
-                                </saml2:AttributeValue>
+                                <xslout:if test=". != ''">
+                                    <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                        <xslout:choose>
+                                            <xslout:when test="exists($type)">
+                                                <xslout:attribute name="xsi:type" select="$type"/>
+                                            </xslout:when>
+                                            <xslout:otherwise>
+                                                <xslout:attribute name="xsi:type">xs:string</xslout:attribute>
+                                            </xslout:otherwise>
+                                        </xslout:choose>
+                                        <xslout:value-of select="mapping:transformNBSP(.)"/>
+                                    </saml2:AttributeValue>
+                                </xslout:if>
                             </xslout:for-each>
                         </saml2:Attribute>
                     </xslout:otherwise>
@@ -182,25 +184,23 @@
                     <xslout:variable name="multiValueAttrib" as="attribute()?" select="($groups/element()[local-name(.)=$extName]/@multiValue)[1]"/>
                     <xslout:variable name="isMultiValue" select="if (exists($multiValueAttrib)) then xs:boolean($multiValueAttrib) else false()" as="xs:boolean"/>
                     <xslout:variable name="values" as="xs:string*" select="if ($isMultiValue) then for $v in $groups/element()[mapping:local-name(.)=$extName]/@value return tokenize($v,' ') else ($groups/element()[mapping:local-name(.)=$extName])[1]/@value"/>
-                    <xslout:if test="not(empty($values)) and not($values='')">
-                        <xslout:element name="attribute">
-                            <xslout:attribute name="name"><xslout:value-of select="$extName"/></xslout:attribute>
-                            <xslout:choose>
-                                <xslout:when test="$isMultiValue">
-                                    <xslout:attribute name="value" select="string-join($values,' ')"/>
-                                </xslout:when>
-                                <xslout:otherwise>
-                                    <xslout:attribute name="value" select="$values"/>
-                                </xslout:otherwise>
-                            </xslout:choose>
-                            <xslout:for-each select="($groups/element()[mapping:local-name(.)=$extName])[1]/@*[not(local-name(.) = ('value','type'))]">
-                                <xslout:attribute>
-                                    <xsl:attribute name="name">{name(.)}</xsl:attribute>
-                                    <xslout:value-of select="."/>
-                                </xslout:attribute>
-                            </xslout:for-each>
-                        </xslout:element>
-                    </xslout:if>
+                    <xslout:element name="attribute">
+                        <xslout:attribute name="name"><xslout:value-of select="$extName"/></xslout:attribute>
+                        <xslout:choose>
+                            <xslout:when test="$isMultiValue">
+                                <xslout:attribute name="value" select="string-join($values,' ')"/>
+                            </xslout:when>
+                            <xslout:otherwise>
+                                <xslout:attribute name="value" select="$values"/>
+                            </xslout:otherwise>
+                        </xslout:choose>
+                        <xslout:for-each select="($groups/element()[mapping:local-name(.)=$extName])[1]/@*[not(local-name(.) = ('value','type'))]">
+                            <xslout:attribute>
+                                <xsl:attribute name="name">{name(.)}</xsl:attribute>
+                                <xslout:value-of select="."/>
+                            </xslout:attribute>
+                        </xslout:for-each>
+                    </xslout:element>
                 </xslout:for-each>
             </xslout:template>
             <xslout:function name="mapping:get-attributes" as="xs:string*">

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion-merge.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion-merge.xml
@@ -51,6 +51,7 @@
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="user/biz"/>
          <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
@@ -65,6 +66,7 @@
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="faws/policy3" mapping:multiValue="true"/>
       </saml2:AttributeStatement>
    </saml2:Assertion>
    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion-single.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion-single.xml
@@ -51,6 +51,7 @@
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="user/biz"/>
          <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
          </saml2:Attribute>
@@ -61,6 +62,7 @@
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="faws/policy3" mapping:multiValue="true"/>
       </saml2:AttributeStatement>
    </saml2:Assertion>
    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion-split.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion-split.xml
@@ -51,6 +51,7 @@
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="user/biz"/>
          <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
              <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
          </saml2:Attribute>
@@ -75,6 +76,7 @@
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="faws/policy3" mapping:multiValue="true"/>
       </saml2:AttributeStatement>
    </saml2:Assertion>
    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/core/src/test/resources/tests/extract-extn-tests/test-assertion.xml
+++ b/core/src/test/resources/tests/extract-extn-tests/test-assertion.xml
@@ -53,6 +53,7 @@
           <saml2:Attribute Name="user/bar">
               <saml2:AttributeValue>bar</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="user/biz"/>
          <saml2:Attribute Name="faws/policy" mapping:multiValue="true">
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy</saml2:AttributeValue>
             <saml2:AttributeValue xsi:type="xs:string">AWSPolicy2</saml2:AttributeValue>
@@ -67,6 +68,7 @@
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy3</saml2:AttributeValue>
               <saml2:AttributeValue xsi:type="xs:string">AWSPolicy YEA!!</saml2:AttributeValue>
           </saml2:Attribute>
+          <saml2:Attribute Name="faws/policy3" mapping:multiValue="true"/>
       </saml2:AttributeStatement>
    </saml2:Assertion>
    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/core/src/test/resources/tests/include/defaults-extn.xml
+++ b/core/src/test/resources/tests/include/defaults-extn.xml
@@ -32,8 +32,14 @@
         <assert test="every $v in /auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='bar']/auth:value satisfies $v=('bar')">
             The value should match correctly.
         </assert>
-        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute) = 2">
-            There should only be two attributes in user
+        <assert test="exists(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='biz'])">
+            The biz attribute should exist
+        </assert>
+        <assert test="empty(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='biz']/auth:value)">
+            The biz attribute should not have a value
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute) = 3">
+            There should only be three attributes in user
         </assert>
         <assert test="/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy']">
             There should be a faws group with policy attribute
@@ -55,6 +61,14 @@
                       ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!','AWSPolicy3','AWSPolicy YEA!!')">
             The values should match correctly
         </assert>
+        <assert
+            test="exists(/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy3'
+                  and @multiValue='true'])">
+            The policy3 attribute should exist and should be multivalue
+        </assert>
+        <assert test="empty(/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy3']/auth:value)">
+            The policy3 attribute should not have a value
+        </assert>
     </assert-group>
     <assert-group name="json">
         <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?user?foo)'>
@@ -73,8 +87,14 @@
         <json-assert test="$_?('RAX-AUTH:extendedAttributes')?user?bar = 'bar'">
             The value of bar should be bar
         </json-assert>
-        <json-assert test='count($_?("RAX-AUTH:extendedAttributes")?user?*) = 2'>
-            There should only be 2 attributes in user
+        <json-assert test="'biz' = map:keys($_?('RAX-AUTH:extendedAttributes')?user)">
+            There should be a user group with a biz attribute.
+        </json-assert>
+        <json-assert test="empty($_?('RAX-AUTH:extendedAttributes')?user?biz)">
+            The value of biz should be empty.
+        </json-assert>
+        <json-assert test='count(map:keys($_?("RAX-AUTH:extendedAttributes")?user)) = 3'>
+            There should only be 3 attributes in user
         </json-assert>
         <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?faws?policy)'>
             There should be a user faws with policy attribute
@@ -95,6 +115,12 @@
         <json-assert test="every $val in $_?('RAX-AUTH:extendedAttributes')?faws?policy2?* satisfies $val=
                            ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!','AWSPolicy3','AWSPolicy YEA!!')">
             The values should match correctly
+        </json-assert>
+        <json-assert test="exists($_?('RAX-AUTH:extendedAttributes')?faws?policy3)">
+            There should be a faws/policy3
+        </json-assert>
+        <json-assert test="count($_?('RAX-AUTH:extendedAttributes')?faws?policy3?*) = 0">
+            The value of faws/policy3  should be empty.
         </json-assert>
     </assert-group>
 </common-assertions>

--- a/core/src/test/resources/tests/include/single-faws-extn.xml
+++ b/core/src/test/resources/tests/include/single-faws-extn.xml
@@ -33,7 +33,13 @@
         <assert test="every $v in /auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='bar']/auth:value satisfies $v=('bar')">
             The value should match correctly.
         </assert>
-        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute) = 2">
+        <assert test="exists(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='biz'])">
+            The biz attribute should exist
+        </assert>
+        <assert test="empty(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute[@name='biz']/auth:value)">
+            The biz attribute should not have a value
+        </assert>
+        <assert test="count(/auth:extendedAttributes/auth:group[@name='user']/auth:attribute) = 3">
             There should only be two attributes in user
         </assert>
         <assert test="/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy']">
@@ -56,6 +62,14 @@
                       ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!','AWSPolicy3','AWSPolicy YEA!!')">
             The values should match correctly
         </assert>
+        <assert
+            test="exists(/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy3'
+                  and @multiValue='true'])">
+            The policy3 attribute should exist and should be multivalue
+        </assert>
+        <assert test="empty(/auth:extendedAttributes/auth:group[@name='faws']/auth:attribute[@name='policy3']/auth:value)">
+            The policy3 attribute should not have a value
+        </assert>
     </assert-group>
     <assert-group name="json">
         <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?user?foo)'>
@@ -74,8 +88,14 @@
         <json-assert test="$_?('RAX-AUTH:extendedAttributes')?user?bar = 'bar'">
             The value of bar should be bar
         </json-assert>
-        <json-assert test='count($_?("RAX-AUTH:extendedAttributes")?user?*) = 2'>
-            There should only be 2 attributes in user
+        <json-assert test="'biz' = map:keys($_?('RAX-AUTH:extendedAttributes')?user)">
+            There should be a user group with a biz attribute.
+        </json-assert>
+        <json-assert test="empty($_?('RAX-AUTH:extendedAttributes')?user?biz)">
+            The value of biz should be empty.
+        </json-assert>
+        <json-assert test='count(map:keys($_?("RAX-AUTH:extendedAttributes")?user)) = 3'>
+            There should only be 3 attributes in user
         </json-assert>
         <json-assert test='exists($_?("RAX-AUTH:extendedAttributes")?faws?policy)'>
             There should be a user faws with policy attribute
@@ -96,6 +116,12 @@
         <json-assert test="every $val in $_?('RAX-AUTH:extendedAttributes')?faws?policy2?* satisfies $val=
                            ('AWSPolicy','AWSPolicy2','AWSPolicy YEA!','AWSPolicy3','AWSPolicy YEA!!')">
             The values should match correctly
+        </json-assert>
+        <json-assert test="exists($_?('RAX-AUTH:extendedAttributes')?faws?policy3)">
+            There should be a faws/policy3
+        </json-assert>
+        <json-assert test="count($_?('RAX-AUTH:extendedAttributes')?faws?policy3?*) = 0">
+            The value of faws/policy3  should be empty.
         </json-assert>
     </assert-group>
 </common-assertions>

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert-observer.xml
@@ -17,10 +17,10 @@
 
 
 <!-- Ensure that faws/nones is not set -->
-<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones'])?>
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/saml2:AttributeValue)?>
 
 <!-- Ensure that faws/admins is not set -->
-<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins'])?>
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins']/saml2:AttributeValue)?>
 
 
 <samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert.xml
@@ -23,7 +23,7 @@
 
 
 <!-- Ensure that faws/nones is not set -->
-<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones'])?>
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/nones']/saml2:AttributeValue)?>
 
 <samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
     Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"

--- a/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
+++ b/core/src/test/resources/tests/mapping-tests/adfs-faws-ext1/asserts/sample_assert_none.xml
@@ -17,10 +17,10 @@
 
 
 <!-- Ensure that faws/observers is not set -->
-<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers'])?>
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/observers']/saml2:AttributeValue)?>
 
 <!-- Ensure that faws/admins is not set -->
-<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins'])?>
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/admins']/saml2:AttributeValue)?>
 
 
 <samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/asserts/sample_assert.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#domain?>
+<?include ../../../include/defaults-asserts.xml#groups?>
+
+
+<!-- email should exist -->
+<?assert exists(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='email']) ?>
+
+<!-- email should be empty -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='email']/saml2:AttributeValue) ?>
+
+<!-- roles extension should exist -->
+<?assert exists(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='roles']) ?>
+
+<!-- roles extension should be multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='roles']/@mapping:multiValue = 'true' ?>
+
+<!-- roles value should be empty -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='roles']/saml2:AttributeValue) ?>
+
+<!-- Foo extension should exist -->
+<?assert exists(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']) ?>
+
+<!-- Foo value should be empty -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/foo']/saml2:AttributeValue) ?>
+
+<!-- bar extension should exist -->
+<?assert exists(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/bar']) ?>
+
+<!-- bar extension should be multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/bar']/@mapping:multiValue = 'true' ?>
+
+<!-- bar value should be empty -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='user/bar']/saml2:AttributeValue) ?>
+
+<!-- faws/spolicy extension should exist -->
+<?assert exists(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/spolicy']) ?>
+
+<!-- faws/spolicy value should be empty -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/spolicy']/saml2:AttributeValue) ?>
+
+
+<!-- faws/policy extension should exist -->
+<?assert exists(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']) ?>
+
+<!-- bar extension should be multivalue -->
+<?assert /saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/@mapping:multiValue = 'true' ?>
+
+<!-- bar value should be empty -->
+<?assert empty(/saml2p:Response/saml2:Assertion[1]/saml2:AttributeStatement/saml2:Attribute[@Name='faws/policy']/saml2:AttributeValue) ?>
+
+
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">nova:admin</saml2:AttributeValue>
+        </saml2:Attribute>
+        <!--
+            This is actually testing that groups should not be copied
+            over, if they are not specified in the policy.
+        -->
+        <saml2:Attribute Name="groups">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group1</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">group2</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">other_group</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2-2-s-ml.yaml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2-2-s-ml.yaml
@@ -1,0 +1,26 @@
+---
+mapping:
+  version: RAX-1
+  rules:
+  - remote:
+    - path: "()"
+    - path: "()"
+      multiValue: true
+    local:
+      user:
+        domain: "{D}"
+        foo:
+          value: "{0}"
+        bar:
+          value: "{1}"
+          multiValue: true
+        name: "{D}"
+        email: "{0}"
+        roles: "{1}"
+        expire: "{D}"
+      faws:
+        spolicy:
+          value: "{0}"
+        policy:
+          value: "{1}"
+          multiValue: true

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2-2.json
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2-2.json
@@ -1,0 +1,39 @@
+{
+  "mapping" : {
+      "rules": [
+          {
+              "remote": [
+                  {
+                      "path":"()"
+                  },
+                  {
+                      "path":"()",
+                      "multiValue" : true
+                  }
+              ],
+              "local": {
+                  "user": {
+                      "domain":"{D}",
+                      "foo": {
+                          "value":"{0}"
+                      },
+                      "bar": {
+                          "value":"{0}",
+                          "multiValue" : true
+                      },
+                      "name":"{D}",
+                      "email":"{0}",
+                      "roles":"{1}",
+                      "expire":"{D}"
+                  },
+                  "faws": {
+                      "spolicy": { "value" : "{0}"},
+                      "policy": { "value" : "{1}", "multiValue" : true }
+                  }
+              }
+          }
+      ],
+    "version":"RAX-1"
+  }
+}
+

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2.json
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2.json
@@ -1,0 +1,39 @@
+{
+  "mapping" : {
+      "rules": [
+          {
+              "remote": [
+                  {
+                      "path":"()"
+                  },
+                  {
+                      "path":"()",
+                      "multiValue" : true
+                  }
+              ],
+              "local": {
+                  "user": {
+                      "domain":"{D}",
+                      "foo": "{0}",
+                      "bar": {
+                          "value": ["{1}"],
+                          "multiValue" : true
+                      },
+                      "name":"{D}",
+                      "email":"{0}",
+                      "roles": {
+                          "value" : ["{1}"],
+                          "multiValue" : true
+                      },
+                      "expire":"{D}"
+                  },
+                  "faws": {
+                      "spolicy": "{0}",
+                      "policy": { "value" : ["{1}"], "multiValue" : true }
+                  }
+              }
+          }
+      ],
+    "version":"RAX-1"
+  }
+}

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2.xml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="{D}"/>
+               <foo value="{0}"  xsi:type="LocalAttribute"/>
+               <bar value="{1}"  multiValue="true" xsi:type="LocalAttribute"/>
+               <name value="{D}"/>
+               <email value="{0}"/>
+               <roles value="{1}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+            <faws xsi:type="LocalAttributeGroup">
+               <spolicy value="{0}" xsi:type="LocalAttribute"/>
+               <policy value="{1}" multiValue="true" xsi:type="LocalAttribute"/>
+            </faws>
+         </local>
+         <remote>
+             <attribute path="()"/>
+             <attribute path="()" multiValue="true"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2.yaml
+++ b/core/src/test/resources/tests/mapping-tests/mapping-rule-ext-attribute-empty/maps/mapping-rule-ext-attribute2.yaml
@@ -1,0 +1,29 @@
+---
+mapping:
+  version: RAX-1
+  rules:
+  - remote:
+    - path: "()"
+    - path: "()"
+      multiValue: true
+    local:
+      user:
+        domain: "{D}"
+        foo: "{0}"
+        bar:
+          value:
+            - "{1}"
+          multiValue: true
+        name: "{D}"
+        email: "{0}"
+        roles:
+          value:
+            - "{1}"
+          multiValue: true
+        expire: "{D}"
+      faws:
+        spolicy: "{0}"
+        policy:
+          value:
+          - "{1}"
+          multiValue: true


### PR DESCRIPTION

An empty value is now represented as null in
`RAX-AUTH:extendedAttributes` or an empty array if it's a multiValue
attribute.

This means slightly modifying the schema in the XML version of `RAX-AUTH:extendedAttributes` to allow sending an attribute with no values.  BTW, attributes with no values are allowed in SAML.