### PR TITLE
Undo "leak fix".

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 1. Block new XPath 3.1 functions such as json-doc.
    1. We now use a REx based XPath 3.1 parser as the Saxon parser does not produce a clean parse tree.
 1. Clean up: Include log4j2 config files in CLI utils and tests so that messages are not lost.
+1. Clean up: No longer create a new XSLT Compiler on every request.
 
 ## Release 2.2.1 (2018-04-16) ##
 1. Fixed a memory leak when compiling and validating policies.

--- a/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
+++ b/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
@@ -91,8 +91,6 @@ object AttributeMapper {
     p
   }
 
-  def newCompiler : XsltCompiler = newProcessor.newXsltCompiler
-
   val processor = {
     val p = newProcessor
 
@@ -332,7 +330,7 @@ object AttributeMapper {
     val outXSL = new XdmDestination
 
     generateXSL (policy, outXSL, validate, xsdEngine)
-    newCompiler.compile(outXSL.getXdmNode.asSource)
+    compiler.compile(outXSL.getXdmNode.asSource)
   }
 
   def generateXSLExec (policy : Document, validate : Boolean, xsdEngine : String) : XsltExecutable = {


### PR DESCRIPTION
I had assumed that the leak was due to XSLT complication, it was
actually due to the Saxon XPath parser. As a result, we undo the
previous "fix", since we now utilize another parser.