### PR TITLE
REP-6920 Provide Consistent Exception Handling

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
    1. We now use a REx based XPath 3.1 parser as the Saxon parser does not produce a clean parse tree.
 1. Clean up: Include log4j2 config files in CLI utils and tests so that messages are not lost.
 1. Clean up: No longer create a new XSLT Compiler on every request.
+1. Clean up: Provide consistent exception handling with new Exception types based off of `AttributeMapperException`.
 
 ## Release 2.2.1 (2018-04-16) ##
 1. Fixed a memory leak when compiling and validating policies.

--- a/cli/addext/src/main/scala/com/rackspace/identity/components/cli/AddExt.scala
+++ b/cli/addext/src/main/scala/com/rackspace/identity/components/cli/AddExt.scala
@@ -35,6 +35,7 @@ import net.sf.saxon.s9api.Destination
 import com.rackspace.com.papi.components.checker.util.URLResolver
 
 import com.rackspace.identity.components.AttributeMapper
+import com.rackspace.identity.components.KnownAttributeMapperException
 
 object AddExt {
   val title = getClass.getPackage.getImplementationTitle
@@ -120,11 +121,15 @@ object AddExt {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((auth : Source, saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
-        AttributeMapper.addExtendedAttributes (auth, saml,  dest, asJSON, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((auth : Source, saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
+          AttributeMapper.addExtendedAttributes (auth, saml,  dest, asJSON, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -132,11 +137,15 @@ object AddExt {
   // Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((auth : Source, saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
-        AttributeMapper.addExtendedAttributes (auth, saml,  dest, asJSON, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((auth : Source, saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
+          AttributeMapper.addExtendedAttributes (auth, saml,  dest, asJSON, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/cli/attribmap/src/main/scala/com/rackspace/identity/components/cli/AttribMap.scala
+++ b/cli/attribmap/src/main/scala/com/rackspace/identity/components/cli/AttribMap.scala
@@ -22,7 +22,7 @@ import javax.xml.transform.stream.StreamSource
 
 import com.martiansoftware.nailgun.NGContext
 import com.rackspace.com.papi.components.checker.util.URLResolver
-import com.rackspace.identity.components.{AttributeMapper, PolicyFormat}
+import com.rackspace.identity.components.{AttributeMapper, PolicyFormat, KnownAttributeMapperException}
 import net.sf.saxon.s9api.Destination
 import org.clapper.argot.ArgotConverters._
 import org.clapper.argot.{ArgotParser, ArgotUsageException}
@@ -110,12 +110,16 @@ object AttribMap {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((policy : Source, policyFormat : PolicyFormat.Value, assertion : Source, dest : Destination,
-                 useSAML : Boolean, validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.convertAssertion (policy, policyFormat, assertion, dest, useSAML, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((policy : Source, policyFormat : PolicyFormat.Value, assertion : Source, dest : Destination,
+                  useSAML : Boolean, validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.convertAssertion (policy, policyFormat, assertion, dest, useSAML, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -123,12 +127,16 @@ object AttribMap {
   //  Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((policy : Source, policyFormat : PolicyFormat.Value, assertion : Source, dest : Destination,
-                 useSAML : Boolean, validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.convertAssertion (policy, policyFormat, assertion, dest, useSAML, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((policy : Source, policyFormat : PolicyFormat.Value, assertion : Source, dest : Destination,
+          useSAML : Boolean, validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.convertAssertion (policy, policyFormat, assertion, dest, useSAML, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/cli/attribmap2json/src/main/scala/com/rackspace/identity/components/cli/AttribMap2JSON.scala
+++ b/cli/attribmap2json/src/main/scala/com/rackspace/identity/components/cli/AttribMap2JSON.scala
@@ -35,6 +35,7 @@ import net.sf.saxon.s9api.Destination
 import com.rackspace.com.papi.components.checker.util.URLResolver
 
 import com.rackspace.identity.components.AttributeMapper
+import com.rackspace.identity.components.KnownAttributeMapperException
 
 object AttribMap2JSON {
   val title = getClass.getPackage.getImplementationTitle
@@ -107,11 +108,15 @@ object AttribMap2JSON {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((policy : Source,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.policy2JSON (policy,  dest, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((policy : Source,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.policy2JSON (policy,  dest, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -119,11 +124,15 @@ object AttribMap2JSON {
   // Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((policy : Source,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.policy2JSON (policy,  dest, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((policy : Source,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.policy2JSON (policy,  dest, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/cli/attribmap2xml/src/main/scala/com/rackspace/identity/components/cli/AttribMap2XML.scala
+++ b/cli/attribmap2xml/src/main/scala/com/rackspace/identity/components/cli/AttribMap2XML.scala
@@ -34,6 +34,7 @@ import net.sf.saxon.s9api.Destination
 import com.rackspace.com.papi.components.checker.util.URLResolver
 
 import com.rackspace.identity.components.AttributeMapper
+import com.rackspace.identity.components.KnownAttributeMapperException
 
 object AttribMap2XML {
   val title = getClass.getPackage.getImplementationTitle
@@ -106,11 +107,15 @@ object AttribMap2XML {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((policy : StreamSource,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.policy2XML (policy,  dest)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((policy : StreamSource,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.policy2XML (policy,  dest)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -118,11 +123,15 @@ object AttribMap2XML {
   // Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((policy : StreamSource,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.policy2XML (policy,  dest)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((policy : StreamSource,  dest : Destination, validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.policy2XML (policy,  dest)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/cli/attribmap2xsl/src/main/scala/com/rackspace/identity/components/cli/AttribMap2XSL.scala
+++ b/cli/attribmap2xsl/src/main/scala/com/rackspace/identity/components/cli/AttribMap2XSL.scala
@@ -22,7 +22,7 @@ import javax.xml.transform.stream.StreamSource
 
 import com.martiansoftware.nailgun.NGContext
 import com.rackspace.com.papi.components.checker.util.URLResolver
-import com.rackspace.identity.components.{AttributeMapper, PolicyFormat}
+import com.rackspace.identity.components.{AttributeMapper, PolicyFormat, KnownAttributeMapperException}
 import net.sf.saxon.s9api.Destination
 import org.clapper.argot.ArgotConverters._
 import org.clapper.argot.{ArgotParser, ArgotUsageException}
@@ -101,12 +101,16 @@ object AttribMap2XSL {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((policy : Source, policyFormat : PolicyFormat.Value, dest : Destination,
-                 validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.generateXSL (policy, policyFormat, dest, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((policy : Source, policyFormat : PolicyFormat.Value, dest : Destination,
+          validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.generateXSL (policy, policyFormat, dest, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -114,12 +118,16 @@ object AttribMap2XSL {
   // Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((policy : Source, policyFormat : PolicyFormat.Value, dest : Destination,
-      validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.generateXSL (policy, policyFormat, dest, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((policy : Source, policyFormat : PolicyFormat.Value, dest : Destination,
+          validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.generateXSL (policy, policyFormat, dest, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/cli/attribmap2yaml/src/main/scala/com/rackspace/identity/components/cli/AttribMap2YAML.scala
+++ b/cli/attribmap2yaml/src/main/scala/com/rackspace/identity/components/cli/AttribMap2YAML.scala
@@ -21,6 +21,7 @@ import javax.xml.transform.stream.StreamSource
 import com.martiansoftware.nailgun.NGContext
 import com.rackspace.com.papi.components.checker.util.URLResolver
 import com.rackspace.identity.components.AttributeMapper
+import com.rackspace.identity.components.KnownAttributeMapperException
 import org.clapper.argot.ArgotConverters._
 import org.clapper.argot.{ArgotParser, ArgotUsageException}
 
@@ -98,12 +99,16 @@ object AttribMap2YAML {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((policy : StreamSource, dest : OutputStream,
-                 validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.policy2YAML (policy, dest, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((policy : StreamSource, dest : OutputStream,
+          validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.policy2YAML (policy, dest, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -111,12 +116,16 @@ object AttribMap2YAML {
   // Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((policy : StreamSource, dest : OutputStream,
-                 validate : Boolean, xsdEngine : String)) =>
-        AttributeMapper.policy2YAML (policy, dest, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((policy : StreamSource, dest : OutputStream,
+          validate : Boolean, xsdEngine : String)) =>
+          AttributeMapper.policy2YAML (policy, dest, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/cli/saml2ext/src/main/scala/com/rackspace/identity/components/cli/SAML2Ext.scala
+++ b/cli/saml2ext/src/main/scala/com/rackspace/identity/components/cli/SAML2Ext.scala
@@ -35,6 +35,7 @@ import net.sf.saxon.s9api.Destination
 import com.rackspace.com.papi.components.checker.util.URLResolver
 
 import com.rackspace.identity.components.AttributeMapper
+import com.rackspace.identity.components.KnownAttributeMapperException
 
 object SAML2Ext {
   val title = getClass.getPackage.getImplementationTitle
@@ -114,11 +115,15 @@ object SAML2Ext {
   // Local run...
   //
   def main(args : Array[String]): Unit = {
-    parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
-               System.in, System.out, System.err) match {
-      case Some((saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
-        AttributeMapper.extractExtendedAttributes (saml,  dest, asJSON, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
+        System.in, System.out, System.err) match {
+        case Some((saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
+          AttributeMapper.extractExtendedAttributes (saml,  dest, asJSON, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => System.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 
@@ -126,11 +131,15 @@ object SAML2Ext {
   // Nailgun run...
   //
   def nailMain(context : NGContext): Unit = {
-    parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
-               context.in, context.out, context.err) match {
-      case Some((saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
-        AttributeMapper.extractExtendedAttributes (saml,  dest, asJSON, validate, xsdEngine)
-      case None => /* Bad args, Ignore */
+    try {
+      parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
+        context.in, context.out, context.err) match {
+        case Some((saml : Source,  dest : Destination, validate : Boolean, xsdEngine : String, asJSON : Boolean)) =>
+          AttributeMapper.extractExtendedAttributes (saml,  dest, asJSON, validate, xsdEngine)
+        case None => /* Bad args, Ignore */
+      }
+    } catch {
+      case e : KnownAttributeMapperException => context.err.println(e.getMessage) // scalastyle:ignore
     }
   }
 }

--- a/core/src/main/resources/jsonSchema/mapping.json
+++ b/core/src/main/resources/jsonSchema/mapping.json
@@ -1,0 +1,170 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON schema for mapping policy",
+    "description" : "A schema for a mapping policy in JSON and YAML. Only captures basic structure, enough to ensure XML translation is successful. Better validation and default value insertion takes place in XML land via the mapping.xsd.",
+    "type": "object",
+    "properties" : {
+        "mapping" : {
+            "$ref" : "#/definitions/mapping"
+        }
+    },
+    "additionalProperties" : false,
+    "required" : ["mapping"],
+    "definitions" : {
+        "mapping" : {
+            "type" : "object",
+            "properties" : {
+                "version" : {
+                    "type" : "string"
+                },
+                "description" : {
+                    "type" : "string"
+                },
+                "rules" : {
+                    "$ref" : "#/definitions/rules"
+                },
+                "namespaces" : {
+                    "$ref" : "#/definitions/namespaces"
+                }
+            },
+            "required" : ["rules"],
+            "additionalProperties" : false
+        },
+        "namespaces" : {
+            "type" : "object",
+            "description" : "Prefix to URL. The prefix should be a valid NCName.",
+            "patternProperties" : {
+                "^[a-zA-Z_][a-zA-Z0-9._-]*$" : {
+                    "type" : "string"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "rules" : {
+            "type" : "array",
+            "minItems" : 1,
+            "items" : {
+                "$ref" : "#/definitions/rule"
+            },
+            "additionalItems" : false
+        },
+        "rule" : {
+            "type" : "object",
+            "properties" : {
+                "local" : {
+                    "$ref" : "#/definitions/localPart"
+                },
+                "remote" : {
+                    "$ref" : "#/definitions/remotePart"
+                }
+            },
+            "required" : ["local"],
+            "additionalProperties" : false
+        },
+        "localPart" : {
+            "type" : "object",
+            "patternProperties" : {
+                "^[a-zA-Z_][a-zA-Z0-9._-]*$" : {
+                    "$ref" : "#/definitions/localGroup"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "localGroup" : {
+            "type" : "object",
+            "patternProperties" : {
+                ".*" : {
+                  "$ref" : "#/definitions/localAttribute"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "remotePart" : {
+            "type" : "array",
+            "items" : {
+                "type" : "object",
+                "properties" : {
+                    "notAnyOf" : {
+                        "$ref" : "#/definitions/attributeValueList"
+                    },
+                    "anyOneOf" : {
+                        "$ref" : "#/definitions/attributeValueList"
+                    },
+                    "blacklist" : {
+                        "$ref" : "#/definitions/attributeValueList"
+                    },
+                    "whitelist" : {
+                        "$ref" : "#/definitions/attributeValueList"
+                    },
+                    "regex" : {
+                        "type" : "boolean"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "path" : {
+                        "type" : "string"
+                    },
+                    "multiValue" : {
+                        "type" : "boolean"
+                    }
+                },
+                "additionalProperties" : false
+            },
+            "additionalItems" : false
+        },
+        "attributeValueList" : {
+            "description" : "A list of attribute values. Single items list can be represented as a single value, multi-items as an array.",
+            "oneOf" : [
+                {
+                    "$ref" : "#/definitions/attributeValue"
+                },
+                {   "type" : "array",
+                    "items" : {
+                        "$ref" : "#/definitions/attributeValue"
+                    }
+                }
+            ]
+        },
+        "attributeValue" : {
+            "description" : "An attribute value may be any datatype except a null",
+            "oneOf" : [
+                {
+                    "type" : "string"
+                },
+                {
+                    "type" : "boolean"
+                },
+                {
+                    "type" : "number"
+                }
+            ]
+        },
+        "localAttribute" : {
+            "description" : "A local attribute can be a string or an attribute object",
+            "oneOf" : [
+                {
+                    "$ref" : "#/definitions/attributeValueList"
+                },
+                {
+                    "$ref" : "#/definitions/localAttributeObject"
+                }
+            ]
+        },
+        "localAttributeObject" : {
+            "type" : "object",
+            "properties" : {
+                "value" : {
+                    "$ref" : "#/definitions/attributeValueList"
+                },
+                "multiValue" : {
+                    "type" : "boolean"
+                },
+                "type" : {
+                    "type" : "string"
+                }
+            },
+            "additionalProperties" : false
+        }
+    }
+}

--- a/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
+++ b/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
@@ -561,7 +561,7 @@ object AttributeMapper {
     generateXSLExec (new DOMSource(policy), PolicyFormat.XML, validate, xsdEngine)
   }
 
-  def parseJsonNode (source : StreamSource) : JsonNode = {
+  def parseJsonNode (source : StreamSource) : JsonNode = handleExceptions[JsonNode] {
     val om = new ObjectMapper()
 
     if (source.getInputStream != null) {
@@ -573,7 +573,7 @@ object AttributeMapper {
     }
   }
 
-  def parseYamlNode (source : StreamSource) : JsonNode = {
+  def parseYamlNode (source : StreamSource) : JsonNode = handleExceptions[JsonNode] {
     val om = new ObjectMapper(new YAMLFactory())
 
     if (source.getInputStream != null) {

--- a/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
+++ b/core/src/main/scala/com/rackspace/identity/components/AttributeMapper.scala
@@ -19,24 +19,38 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, InputStream, 
 import java.net.URI
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.transform.Source
+import javax.xml.transform.ErrorListener
+import javax.xml.transform.TransformerException
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.sax.SAXResult
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.{Schema, SchemaFactory}
 
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException
+
+import com.github.fge.jsonschema.main.JsonSchemaFactory
+import com.github.fge.jsonschema.report.{ListReportProvider, LogLevel}
+import com.github.fge.jsonschema.exceptions.ProcessingException
+
 import com.rackspace.cloud.api.wadl.util.LogErrorListener
 import com.rackspace.com.papi.components.checker.util.XMLParserPool
 import net.sf.saxon.Configuration.LicenseFeature._
 import net.sf.saxon.s9api._
 import net.sf.saxon.serialize.MessageWarner
-import net.sf.saxon.trans.XPathException
 import net.sf.saxon.lib.FeatureKeys
 import org.w3c.dom.Document
 
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+import org.xml.sax.ErrorHandler
+import org.xml.sax.SAXParseException
+
 import scala.util.Try
+import scala.collection.JavaConversions._
 
 import collection.JavaConverters._
 
@@ -59,7 +73,86 @@ object PolicyFormat extends Enumeration {
   }
 }
 
-class UnsupportedPolicyFormatException(message: String) extends Exception(message)
+//
+//  Exceptions
+//
+
+
+//
+// Generic Attribute Mapper Exception, should anything else go wrong.
+//
+class AttributeMapperException(message: String, cause : Throwable) extends Exception(message, cause) {
+  def this(message : String) {
+    this(message, null)
+  }
+}
+
+
+//
+//  An attribute mapper execption where the cause of the error is
+//  known. (ie it's not a catch for an unknown Exception).  It should
+//  always be safe to reveal to the end user the message of a
+//  known exception.
+//
+abstract class KnownAttributeMapperException(message : String, cause : Throwable) extends AttributeMapperException(message, cause) {
+  def this(message : String) {
+    this(message, null)
+  }
+}
+
+//
+//  Thrown if the policy format is not supported.
+//
+class UnsupportedPolicyFormatException(message: String) extends KnownAttributeMapperException(message)
+
+//
+//  Thrown if the policy is malformed in some way: bad XML, JSON,
+//  YAML.  The cause will likely come from the XML, JSON, YAML parser.
+//
+class ParseException(message : String, cause : Throwable) extends KnownAttributeMapperException(message, cause)
+
+//
+//  Thrown if there's a validation error the cause will likely be the
+//  exception from the XSD impl.
+//
+class ValidationException(message : String, cause : Throwable) extends KnownAttributeMapperException(message, cause)
+
+//
+//  The policy itself is valid according to schema, but there's an
+//  issue with an XPath in the policy.
+//
+class XPathException(message : String) extends ValidationException(message, null)
+
+//
+//  A Generic Validation Error Handler : Allows us to sort out the
+//  differences of handling validation errors between Xerces and Saxon
+//
+private class GenericValidationErrorHandler[T <: Exception] extends LazyLogging {
+  def fatalError(te : T) : Unit = {
+    throw new ValidationException (te.getMessage, te)
+  }
+
+  def error(te : T) : Unit = {
+    //
+    // All errors are fatal!
+    //
+    fatalError(te)
+  }
+
+  def warning(te : T) : Unit = {
+    logger.warn (te.getMessage, te)
+  }
+}
+
+//
+//  Saxon error listener...
+//
+private object ValidationErrorListener extends GenericValidationErrorHandler[TransformerException] with ErrorListener {}
+
+//
+//  Xerces error handler...
+//
+private object ValidationErrorHandler extends GenericValidationErrorHandler[SAXParseException] with ErrorHandler {}
 
 import com.rackspace.identity.components.XSDEngine._
 import com.rackspace.identity.components.PolicyFormat._
@@ -213,25 +306,127 @@ object AttributeMapper {
      || engine == SAXON)
   }
 
-  def validate(src : Source, engineStr : String, schema : => Schema, schemaManager : => SchemaManager) : Source = {
+
+  private lazy val jsonSchemaFactory = JsonSchemaFactory.newBuilder.setReportProvider(new ListReportProvider(LogLevel.WARNING, LogLevel.ERROR)).freeze
+  private lazy val mappingJSONSchema = {
+    val om = new ObjectMapper
+    val grammar = om.readValue(getClass.getResource("/jsonSchema/mapping.json"), classOf[JsonNode])
+    jsonSchemaFactory.getJsonSchema(grammar)
+  }
+
+  //
+  //  All of the logic for wrapping exceptions into Attribute Mapping
+  //  Exceptions here.
+  //
+  private def handleExceptions[T](tryFun :  => T) : T = {
+    try {
+      tryFun
+    } catch {
+      //
+      //  Pass attribute mapper exceptions through...
+      //
+      case ae : AttributeMapperException => throw ae
+
+      //
+      //  Parse Exceptions
+      //
+      case sae : SaxonApiException if (sae.getMessage.contains("ParseException")) =>
+        throw new ParseException(sae.getMessage, sae)
+      case spe : SAXParseException =>
+        throw new ParseException(spe.getMessage, spe)
+      case mye : MarkedYAMLException =>
+        throw new ParseException(mye.getMessage, mye)
+      case jpe : JsonParseException =>
+        throw new ParseException(jpe.getMessage, jpe)
+
+      //
+      // Validation Exceptions
+      //
+      case pe : ProcessingException =>
+        throw new ValidationException (processingException2Message(pe), pe)
+
+      //
+      //  No idea, man.
+      //
+      case t : Throwable => throw new AttributeMapperException("Error while processing mapping policy", t)
+    }
+  }
+
+  private def getJsonSchemaMessagesFromReports (reports : JsonNode, current : Option[String]) : List[String] = {
+    val allReports : Iterator[JsonNode] = reports.elements.flatMap(a => a.elements.asInstanceOf[java.util.Iterator[JsonNode]])
+    val allReportMessages : List[String] = allReports.flatMap(r => getJsonSchemaMessages(r)).toList
+
+    current match {
+      case Some(msg) => msg :: allReportMessages
+      case None => allReportMessages
+    }
+  }
+
+  private def getJsonSchemaMessages (report : JsonNode) : List[String] = {
+    val currentMessage : Option[JsonNode] =  Some(report.findValue("message"))
+    val reports : Option[JsonNode] = Some(report.findValue("reports"))
+    val pointer : Option[JsonNode] = Some(report.findValue("instance")).map(_.findValue("pointer"))
+
+    val pointerString : String = pointer match {
+      case Some(pointerNode : JsonNode) => " in " + pointerNode.asText
+      case _ => ""
+    }
+
+    val withCurrentMessage : Option[String] = currentMessage match {
+      case Some(msgNode : JsonNode) => Some(msgNode.asText + pointerString)
+      case _ => None
+    }
+
+    reports match {
+      case Some(reportNode : JsonNode) => getJsonSchemaMessagesFromReports (reportNode, withCurrentMessage)
+      case _ => withCurrentMessage match {
+        case Some(msg) => List(msg)
+        case None => Nil
+      }
+    }
+  }
+
+  private def processingException2Message (pe : ProcessingException) : String = {
+    val errorAsJSON = pe.getProcessingMessage.asJson
+    Some(errorAsJSON.findValue("message")) match {
+      case Some(msgNode : JsonNode) if (msgNode.isTextual) => getJsonSchemaMessages(errorAsJSON).mkString("\n")
+      case _ => pe.getProcessingMessage.toString
+    }
+  }
+
+  def validate(src : Source, engineStr : String, schema : => Schema, schemaManager : => SchemaManager) : Source = handleExceptions[Source] {
     val docBuilder = processor.newDocumentBuilder
     val bch = docBuilder.newBuildingContentHandler
 
     if (useSaxon(engineStr)) {
       Console.err.println("Saxon validation") // scalastyle:ignore
       val svalidator = schemaManager.newSchemaValidator
+      svalidator.setErrorListener (ValidationErrorListener)
       svalidator.setDestination(new SAXDestination(bch))
       svalidator.validate(src)
     } else {
       Console.err.println("Xerces validation") // scalastyle:ignore
       val schemaHandler = schema.newValidatorHandler
       schemaHandler.setContentHandler(bch)
-      idTransform.transform(src, new SAXResult(schemaHandler))
+      schemaHandler.setErrorHandler(ValidationErrorHandler)
+      //
+      //  Xerces does not honor the ValidationErrorHandler when
+      //  throwing errors due to assertions failing. If we get an
+      //  exception from Saxon and the cause is a SAXParseException we
+      //  assume it's coming from Xerces and we pass it on the
+      //  handler ourselves.
+      //
+      try {
+        idTransform.transform(src, new SAXResult(schemaHandler))
+      } catch {
+        case xpe : net.sf.saxon.trans.XPathException if Option(xpe.getCause).exists(_.isInstanceOf[SAXParseException]) =>
+          ValidationErrorHandler.fatalError(xpe.getCause.asInstanceOf[SAXParseException])
+      }
     }
     bch.getDocumentNode.asSource
   }
 
-  def validatePolicy (policy : Source, engineStr : String) : Source = {
+  def validatePolicy (policy : Source, engineStr : String) : Source = handleExceptions[Source] {
     val docBuilder = processor.newDocumentBuilder
     val xdmPolicy = docBuilder.build(policy)
     val outXPathErrors = new XdmDestination
@@ -267,43 +462,60 @@ object AttributeMapper {
     goodPolicy
   }
 
-  def validatePolicy (policy : JsonNode, engineStr : String) : JsonNode = {
-    val outXMLPolicy = new XdmDestination
-
-    policy2XML(policy, outXMLPolicy)
-    val valXMLPolicySrc = validatePolicy(outXMLPolicy.getXdmNode.asSource, engineStr)
-
+  def validatePolicy (policy : JsonNode, engineStr : String) : JsonNode = handleExceptions[JsonNode] {
+    //
+    //  Validate then return JSON node.
+    //
     val bout = new ByteArrayOutputStream
     val dest = processor.newSerializer(bout)
-
-    policy2JSON(valXMLPolicySrc, dest, false, engineStr)
+    policy2JSON(validatePolicyToXML(policy, engineStr), dest, false, engineStr)
 
     val bin = new ByteArrayInputStream(bout.toByteArray)
     parseJsonNode(new StreamSource(bin))
   }
 
-  def generateXSL (policy : Source, policyFormat : PolicyFormat.Value, xsl : Destination, validate : Boolean, xsdEngine : String) : Unit = {
-    val policySourceConv1 = policyFormat match {
+  def validatePolicyToXML (policy : JsonNode, engineStr : String) : Source = handleExceptions[Source] {
+    //
+    //  Validate as JSON
+    //
+    mappingJSONSchema.validate(policy)
+
+    //
+    //  Convert to XML and Validate as XML. This produces new XML with
+    //  defaults filled in.
+    //
+    val outXMLPolicy = new XdmDestination
+    policy2XML(policy, outXMLPolicy)
+    validatePolicy(outXMLPolicy.getXdmNode.asSource, engineStr)
+  }
+
+  def generateXSL (policy : Source, policyFormat : PolicyFormat.Value, xsl : Destination,
+    validate : Boolean, xsdEngine : String) : Unit = handleExceptions[Unit] {
+    val policySrc = policyFormat match {
       case PolicyFormat.YAML =>
-        val outPolicyXML = new XdmDestination
-        policy2XML(parseYamlNode(policy.asInstanceOf[StreamSource]), outPolicyXML)
-        outPolicyXML.getXdmNode.asSource
+        if (validate) {
+          validatePolicyToXML(parseYamlNode(policy.asInstanceOf[StreamSource]), xsdEngine)
+        } else {
+          val outPolicyXML = new XdmDestination
+          policy2XML(parseYamlNode(policy.asInstanceOf[StreamSource]), outPolicyXML)
+          outPolicyXML.getXdmNode.asSource
+        }
       case PolicyFormat.JSON =>
-        val outPolicyXML = new XdmDestination
-        policy2XML(policy.asInstanceOf[StreamSource], outPolicyXML)
-        outPolicyXML.getXdmNode.asSource
+        if (validate) {
+          validatePolicyToXML(parseJsonNode(policy.asInstanceOf[StreamSource]), xsdEngine)
+        } else {
+          val outPolicyXML = new XdmDestination
+          policy2XML(policy.asInstanceOf[StreamSource], outPolicyXML)
+          outPolicyXML.getXdmNode.asSource
+        }
       case PolicyFormat.XML =>
-        policy
+        if (validate) {
+          validatePolicy(policy, xsdEngine)
+        } else {
+          policy
+        }
       case _ =>
         throw new UnsupportedPolicyFormatException(s"The Policy Format $policyFormat is not supported at this time.")
-    }
-
-    val policySrc = {
-      if (validate) {
-        validatePolicy(policySourceConv1, xsdEngine)
-      } else {
-        policySourceConv1
-      }
     }
 
     val mappingTrans = getXsltTransformer(mapperXsltExec)
@@ -312,28 +524,40 @@ object AttributeMapper {
     mappingTrans.transform()
   }
 
-  def generateXSL (policy : JsonNode, xsl : Destination, validate : Boolean, xsdEngine : String) : Unit = {
-    val outPolicyXML = new XdmDestination
-    policy2XML(policy, outPolicyXML)
+  def generateXSL (policy : JsonNode, xsl : Destination, validate : Boolean,
+    xsdEngine : String) : Unit = handleExceptions[Unit] {
 
-    generateXSL(outPolicyXML.getXdmNode.asSource, PolicyFormat.XML, xsl, validate, xsdEngine)
+    val policySrc = {
+      if (validate) {
+        validatePolicyToXML(policy, xsdEngine)
+      } else {
+        val outPolicyXML = new XdmDestination
+        policy2XML(policy, outPolicyXML)
+        outPolicyXML.getXdmNode.asSource
+      }
+    }
+
+    generateXSL(policySrc, PolicyFormat.XML, xsl, false, xsdEngine)
   }
 
-  def generateXSLExec (policy : Source, policyFormat : PolicyFormat.Value, validate : Boolean, xsdEngine : String) : XsltExecutable = {
+  def generateXSLExec (policy : Source, policyFormat : PolicyFormat.Value,
+    validate : Boolean, xsdEngine : String) : XsltExecutable = handleExceptions[XsltExecutable] {
     val outXSL = new XdmDestination
 
     generateXSL (policy, policyFormat, outXSL, validate, xsdEngine)
     compiler.compile(outXSL.getXdmNode.asSource)
   }
 
-  def generateXSLExec (policy : JsonNode, validate : Boolean, xsdEngine : String) : XsltExecutable = {
+  def generateXSLExec (policy : JsonNode, validate : Boolean,
+    xsdEngine : String) : XsltExecutable = handleExceptions[XsltExecutable] {
     val outXSL = new XdmDestination
 
     generateXSL (policy, outXSL, validate, xsdEngine)
     compiler.compile(outXSL.getXdmNode.asSource)
   }
 
-  def generateXSLExec (policy : Document, validate : Boolean, xsdEngine : String) : XsltExecutable = {
+  def generateXSLExec (policy : Document, validate : Boolean,
+    xsdEngine : String) : XsltExecutable = handleExceptions[XsltExecutable] {
     generateXSLExec (new DOMSource(policy), PolicyFormat.XML, validate, xsdEngine)
   }
 
@@ -361,7 +585,8 @@ object AttributeMapper {
     }
   }
 
-  def policy2JSON(policyXML : Source, policyJSON : Destination, validate : Boolean, xsdEngine : String) : Unit = {
+  def policy2JSON(policyXML : Source, policyJSON : Destination, validate : Boolean,
+    xsdEngine : String) : Unit = handleExceptions[Unit] {
     val policySrc = {
       if (validate) {
         validatePolicy(policyXML, xsdEngine)
@@ -376,11 +601,11 @@ object AttributeMapper {
     evaluator.run()
   }
 
-  def policy2XML(policyJSON : StreamSource, policyXML : Destination) : Unit = {
+  def policy2XML(policyJSON : StreamSource, policyXML : Destination) : Unit = handleExceptions[Unit] {
     policy2XML(parseJsonNode(policyJSON), policyXML)
   }
 
-  def policy2XML(node : JsonNode, policyXML : Destination) : Unit = {
+  def policy2XML(node : JsonNode, policyXML : Destination) : Unit = handleExceptions[Unit] {
     val om = new ObjectMapper()
 
     val evaluator = getXQueryEvaluator(mapper2XMLExec, Map[QName, XdmValue](new QName("__JSON__") -> new XdmAtomicValue(om.writeValueAsString(node))))
@@ -388,7 +613,7 @@ object AttributeMapper {
     evaluator.run()
   }
 
-  def policy2YAML(policyJSON : StreamSource, policyYAML : OutputStream, validate : Boolean, xsdEngine : String) : Unit = {
+  def policy2YAML(policyJSON : StreamSource, policyYAML : OutputStream, validate : Boolean, xsdEngine : String) : Unit = handleExceptions[Unit] {
     val yamlMapper = new ObjectMapper(new YAMLFactory())
     val policyJson = parseJsonNode(policyJSON)
 
@@ -405,7 +630,7 @@ object AttributeMapper {
 
   def convertAssertion (policy : Source, policyFormat : PolicyFormat.Value, assertion : Source, dest : Destination,
                         outputSAML : Boolean, validate : Boolean, xsdEngine : String,
-                         params : Map[String,String]=Map[String,String]()) : Unit = {
+                         params : Map[String,String]=Map[String,String]()) : Unit = handleExceptions[Unit] {
     //
     // Generate the XSLTExec
     //
@@ -418,7 +643,7 @@ object AttributeMapper {
   }
 
   def convertAssertion (policyExec : XsltExecutable, assertion : Source, dest : Destination, outputSAML : Boolean, toJSON : Boolean,
-                        params : Map[String,String]) : Unit = {
+                        params : Map[String,String]) : Unit = handleExceptions[Unit] {
     val assertionDest = {
       if (toJSON && !outputSAML) {
         new XdmDestination
@@ -441,7 +666,8 @@ object AttributeMapper {
     }
   }
 
-  def convertAssertion (policyExec : XsltExecutable, assertion : Source, params : Map[String,String]) : Document = {
+  def convertAssertion (policyExec : XsltExecutable, assertion : Source,
+    params : Map[String,String]) : Document = handleExceptions[Document] {
     var docBuilder : DocumentBuilder = null
     var outDoc : Document = null
     try {
@@ -456,15 +682,17 @@ object AttributeMapper {
     outDoc
   }
 
-  def convertAssertion (policyExec : XsltExecutable, assertion : Document, params : Map[String,String]) : Document = {
+  def convertAssertion (policyExec : XsltExecutable, assertion : Document,
+    params : Map[String,String]) : Document = handleExceptions[Document] {
     convertAssertion (policyExec, new DOMSource(assertion), params)
   }
 
-  def validateExtAttributes (extAttribs : Source, engineStr : String) : Source = {
+  def validateExtAttributes (extAttribs : Source, engineStr : String) : Source = handleExceptions[Source] {
     validate (extAttribs, engineStr, extAttribsSchema, extAttribsSchemaManager)
   }
 
-  def extractExtendedAttributes (assertion : Source, extendedAttribs : Destination, asJSON : Boolean, validate : Boolean, xsdEngine : String) : Unit = {
+  def extractExtendedAttributes (assertion : Source, extendedAttribs : Destination, asJSON : Boolean,
+    validate : Boolean, xsdEngine : String) : Unit = handleExceptions[Unit] {
     val xdmDest = new XdmDestination
 
     val dest : Destination = {
@@ -494,7 +722,7 @@ object AttributeMapper {
     }
   }
 
-  def extractExtendedAttributes (assertion : Source, validate : Boolean, xsdEngine : String) : JsonNode = {
+  def extractExtendedAttributes (assertion : Source, validate : Boolean, xsdEngine : String) : JsonNode = handleExceptions[JsonNode] {
     val om = new ObjectMapper
     val bout = new ByteArrayOutputStream
     val dest = processor.newSerializer (bout)
@@ -504,7 +732,7 @@ object AttributeMapper {
   }
 
   def addExtendedAttributes (authResp : Source, assertion : Source, newAuthResp : Destination,
-                             isJSON : Boolean, validate : Boolean, xsdEngine : String) : Unit = {
+                             isJSON : Boolean, validate : Boolean, xsdEngine : String) : Unit = handleExceptions[Unit] {
     if (!isJSON) {
       addExtendedAttributes (authResp, assertion, newAuthResp, validate, xsdEngine)
     } else {
@@ -519,7 +747,7 @@ object AttributeMapper {
   }
 
   def addExtendedAttributes (authResp : Source, assertion : Source, newAuthResp : Destination,
-                             validate : Boolean, xsdEngine : String) : Unit = {
+                             validate : Boolean, xsdEngine : String) : Unit = handleExceptions[Unit] {
     val extDest = new XdmDestination
     extractExtendedAttributes (assertion, extDest, false, validate, xsdEngine)
 
@@ -529,7 +757,8 @@ object AttributeMapper {
     joinExtTrans.transform()
   }
 
-  def addExtendedAttributes (authResp : Source, assertion : Document, validate : Boolean, xsdEngine : String) : Document = {
+  def addExtendedAttributes (authResp : Source, assertion : Document,
+    validate : Boolean, xsdEngine : String) : Document = handleExceptions[Document] {
     var docBuilder : DocumentBuilder = null
     var outDoc : Document = null
     try {
@@ -545,11 +774,13 @@ object AttributeMapper {
     outDoc
   }
 
-  def addExtendedAttributes (authResp : Document, assertion : Document, validate : Boolean, xsdEngine : String) : Document = {
+  def addExtendedAttributes (authResp : Document, assertion : Document,
+    validate : Boolean, xsdEngine : String) : Document = handleExceptions[Document] {
     addExtendedAttributes (new DOMSource(authResp), assertion, validate, xsdEngine)
   }
 
-  def addExtendedAttributes (authResp : JsonNode, assertion : Source, validate : Boolean, xsdEngine : String) : JsonNode = {
+  def addExtendedAttributes (authResp : JsonNode, assertion : Source,
+    validate : Boolean, xsdEngine : String) : JsonNode = handleExceptions[JsonNode] {
     val extAttribs = extractExtendedAttributes (assertion, validate, xsdEngine)
     val retResp : ObjectNode  = authResp.deepCopy[ObjectNode]
     if (extAttribs.get("RAX-AUTH:extendedAttributes").size != 0) {
@@ -559,11 +790,13 @@ object AttributeMapper {
     retResp
   }
 
-  def addExtendedAttributes (authResp : StreamSource, assertion : Source, validate : Boolean, xsdEngine : String) : JsonNode = {
+  def addExtendedAttributes (authResp : StreamSource, assertion : Source,
+    validate : Boolean, xsdEngine : String) : JsonNode = handleExceptions[JsonNode] {
     addExtendedAttributes (parseJsonNode(authResp), assertion, validate, xsdEngine)
   }
 
-  def addExtendedAttributes (authResp : JsonNode, assertion : Document, validate : Boolean, xsdEngine : String) : JsonNode = {
+  def addExtendedAttributes (authResp : JsonNode, assertion : Document,
+    validate : Boolean, xsdEngine : String) : JsonNode = handleExceptions[JsonNode] {
     addExtendedAttributes (authResp, new DOMSource(assertion), validate, xsdEngine)
   }
 }

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/asserts/sample_assert.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include defaults assertions -->
+<?include ../../../include/defaults-asserts.xml#common?>
+<?include ../../../include/defaults-asserts.xml#name?>
+<?include ../../../include/defaults-asserts.xml#expire?>
+<?include ../../../include/defaults-asserts.xml#email?>
+
+<!-- There should be 2 roles -->
+<?assert count(mapping:get-attributes('roles')) = 2?>
+
+<!-- The roles should either be nova:observer, lbaas:observer OR nova:admin, lbaas:admin-->
+<?assert (every $r in ('lbaas:observer','nova:observer') satisfies $r=mapping:get-attributes('roles')) or
+         (every $r in ('lbaas:admin','nova:admin') satisfies $r=mapping:get-attributes('roles'))?>
+
+<!-- The doman should be 78334 -->
+<?assert mapping:get-attribute('domain') = '78334'?>
+
+<saml2p:Response ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://test.rackspace.com</saml2:Issuer>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    ID="_406fb7fe-a519-4919-a42c-f67794a670a5" IssueInstant="2013-11-15T16:19:06.310Z"
+    Version="2.0">
+    <saml2:Issuer>http://my.rackspace.com</saml2:Issuer>
+    <saml2:Subject>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">john.doe</saml2:NameID>
+        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData
+                NotOnOrAfter="2013-11-17T16:19:06.298Z" />
+        </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:AuthnStatement AuthnInstant="2013-11-15T16:19:04.055Z">
+        <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+            </saml2:AuthnContextClassRef>
+        </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+        <saml2:Attribute Name="roles">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">FOO</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">BING</saml2:AttributeValue>
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xsi:type="xs:string">Contractor</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="domain">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">323676</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="email">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">no-reply@rackspace.com</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="bar">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">BAR!</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="FirstName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">John</saml2:AttributeValue>
+        </saml2:Attribute>
+        <saml2:Attribute Name="LastName">
+            <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:type="xs:string">Doe</saml2:AttributeValue>
+        </saml2:Attribute>
+    </saml2:AttributeStatement>
+   </saml2:Assertion>
+</saml2p:Response>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-heredoc.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-heredoc.yaml
@@ -1,0 +1,22 @@
+---
+mapping:
+  rules:
+    - remote:
+      - path: |
+         (:
+            If the number of seconds is even, then the role should be
+            nova:admin and lbaas:admin
+
+            Otherwise the roles should be nova:observe and lbaas:observer.
+         :)
+         if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0)
+               then ('nova:admin','lbaas:admin')  else foo:other()
+        multiValue: true
+      local:
+        user:
+          domain: '78334'
+          name: "{D}"
+          email: "{D}"
+          roles: "{0}"
+          expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-heredoc.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-heredoc.yaml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.json
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.json
@@ -1,0 +1,18 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "local": {
+          "user": {
+            "domain":"78334",
+            "name":"{D}",
+            "email":"{D}",
+            "roles": ["{Pts(if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin')  else foo:other() )}"],
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.json.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="78334"/>
+               <roles value="{Pts(if
+                             ((xs:integer(seconds-from-time(current-time()))
+                             mod 2) = 0) then ('nova:admin',
+                             'lbaas:admin')  else foo:other() )}"/>
+            </user>
+         </local>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.xml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.yaml
@@ -1,0 +1,13 @@
+---
+mapping:
+  rules:
+  - local:
+      user:
+        domain: '78334'
+        name: "{D}"
+        email: "{D}"
+        roles:
+          - "{Pts(if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0)
+          then ('nova:admin', 'lbaas:admin')  else foo:other() )}"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix-s.yaml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.json
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.json
@@ -1,0 +1,24 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "path":"if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin')  else foo:other()",
+            "multiValue":true
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"78334",
+            "name":"{D}",
+            "email":"{D}",
+            "roles": ["{0}"],
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.json.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="78334"/>
+               <roles value="{0}"/>
+            </user>
+         </local>
+        <remote>
+            <attribute multiValue="true"
+                       path="if
+                             ((xs:integer(seconds-from-time(current-time()))
+                             mod 2) = 0) then ('nova:admin',
+                             'lbaas:admin') else foo:other()"/>
+        </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.xml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.yaml
@@ -1,0 +1,16 @@
+---
+mapping:
+  rules:
+    - remote:
+      - path: "if ((xs:integer(seconds-from-time(current-time())) mod
+      2) = 0) then ('nova:admin', 'lbaas:admin') else foo:other()"
+        multiValue: true
+      local:
+        user:
+          domain: '78334'
+          name: "{D}"
+          email: "{D}"
+          roles:
+            - "{0}"
+          expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-bad-prefix.yaml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>prefix 'foo' is not defined</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-heredoc.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-heredoc.yaml
@@ -1,0 +1,22 @@
+---
+mapping:
+  rules:
+    - remote:
+      - path: |
+         (:
+            If the number of seconds is even, then the role should be
+            nova:admin and lbaas:admin
+
+            Otherwise the roles should be nova:observe and lbaas:observer.
+         :)
+         if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0)
+               then ('nova:admin','lbaas:admin')
+        multiValue: true
+      local:
+        user:
+          domain: '78334'
+          name: "{D}"
+          email: "{D}"
+          roles: "{0}"
+          expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-heredoc.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-heredoc.yaml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.json
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.json
@@ -1,0 +1,18 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "local": {
+          "user": {
+            "domain":"78334",
+            "name":"{D}",
+            "email":"{D}",
+            "roles": ["{Pts(if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin'))}"],
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.json.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="78334"/>
+               <roles value="{Pts(if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin'))}"/>
+            </user>
+         </local>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.xml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.yaml
@@ -1,0 +1,13 @@
+---
+mapping:
+  rules:
+  - local:
+      user:
+        domain: '78334'
+        name: "{D}"
+        email: "{D}"
+        roles:
+          - "{Pts(if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0)
+          then ('nova:admin', 'lbaas:admin'))}"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else-s.yaml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.json
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.json
@@ -1,0 +1,24 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "path":"if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin')",
+            "multiValue":true
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"78334",
+            "name":"{D}",
+            "email":"{D}",
+            "roles": ["{0}"],
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.json.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="RAX-1">
+   <rules>
+      <rule>
+        <local>
+            <user>
+               <name value="{D}"/>
+               <email value="{D}"/>
+               <expire value="{D}"/>
+               <domain value="78334"/>
+               <roles value="{0}"/>
+            </user>
+         </local>
+        <remote>
+            <attribute multiValue="true"
+                       path="if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin')"/>
+        </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.xml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.yaml
@@ -1,0 +1,15 @@
+---
+mapping:
+  rules:
+    - remote:
+      - path: "if ((xs:integer(seconds-from-time(current-time())) mod 2) = 0) then ('nova:admin', 'lbaas:admin')"
+        multiValue: true
+      local:
+        user:
+          domain: '78334'
+          name: "{D}"
+          email: "{D}"
+          roles:
+            - "{0}"
+          expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid-xpath/name-and-roles-xpath/maps/name-and-roles-xpath-missing-else.yaml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>syntax error</contains>
+    <contains>expecting</contains>
+    <contains>else</contains>
+    <contains>in XPath</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/asserts/sample_assert.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include all adfs-specific assertions -->
+<?include ../../../include/adfs-asserts.xml?>
+
+<!-- The roles should be set -->
+<?assert every $r in ('Domain Users','RAX-identity~admin','RAX-nova~admin','RACK-Domain-5821005') satisfies $r=mapping:get-attributes('roles')?>
+
+<samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
+    Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"
+    ID="_1105c5b8-28d4-45e5-a6e4-bc4179f5a111" IssueInstant="2016-11-18T18:54:55.572Z" Version="2.0"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1105c5b8-28d4-45e5-a6e4-bc4179f5a111">
+                <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>JaeeD+wkw297KPF+BKpdacRtaPmQKFD+DqXQ3JE3Aus=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>kDBwO3xYaxITVS7ZZIy9AGOlk16Y5E0BlqU12QlRpWGfiwjtgok4p5q3YQS+N/Pxh84JUIjd7i+n0to/2yJyaCfoSA2SIUUf448lTtHNzVmjiC4WiUmUTRGaxUpsdcYUkjFAVAS40yGDBLXMYn/JYS4cbRV52/RTJ5smCCpqBMjgzhVaeAqJif/gXGjvMLl4RFN8JGvHZGzpjCb14UdKhVqfP0ZumLo4cLIWd3Ch49zRBQBgchbFqEJbTdPPLTJ4SMIEYm5RwX4PtQ2Ce94u8IGXkIhYf32H43l+955a35XGh37hcZMLZEzjk4FBMqSScupKqDej1c0m34MkeRGMlQ==</ds:SignatureValue>
+        <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+                <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+            </ds:X509Data>
+        </KeyInfo>
+    </ds:Signature>
+    <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+    <Assertion ID="_a8a6920c-d4eb-467f-85df-6fa2767ae63d" IssueInstant="2016-11-18T18:54:55.571Z"
+        Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+        <Issuer>http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+                    <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>uQmSKQT03SRunafqzpb6v159a+jMVvTqmBCFYn17e7s=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>cYKqfE92hWqaPylJIcl89U9TKNzJXcFIPO0fvohg70zLB4JWnYlIKOz7S9XFUvS24mN47XS1T8DeR0IGITBMhqA/GCM624SOW0QjIRhQ9gh6/ONlyuAxGbVDo5tYb82sICFa9sMWI2Vr5ZH2LeTqyvsBRnlWBkZIw4hS2PBDHbhcnILUGX9uUDRcOrONAEMimnB7cNmZxSwQgdPfupyS39oedrUAiORa7GMII8GglWoj6Jy8SX0fQKXfsXD+wC5XFw76WAKJjSCuEkrXfxMQia/2H1tE24zNgZd6Y+uQ2Nh8YlUvO+DaMoj7mTKZUBqlxQt6It4kGH0+hfqvWx1MHQ==</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+                </ds:X509Data>
+            </KeyInfo>
+        </ds:Signature>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">btables@contosowidgets.loc</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData NotOnOrAfter="2016-11-18T18:59:55.572Z"
+                Recipient="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"/></SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2016-11-18T18:54:55.551Z" NotOnOrAfter="2016-11-18T19:54:55.551Z">
+            <AudienceRestriction>
+                <Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+                <AttributeValue>btables@contosowidgets.loc</AttributeValue>
+            </Attribute>
+            <Attribute Name="domain">
+                <AttributeValue>5821005</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+                <AttributeValue>Domain Users</AttributeValue>
+                <AttributeValue>RAX-identity~admin</AttributeValue>
+                <AttributeValue>RAX-nova~admin</AttributeValue>
+                <AttributeValue>RACK-Domain-5821005</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2016-11-18T18:30:55.359Z"
+            SessionIndex="_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+            <AuthnContext>
+                <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.json
@@ -1,0 +1,30 @@
+ {
+  "wooga": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>not allowed</contains>
+    <contains>wooga</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wooga xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</wooga>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.xml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>Cannot</contains>
+    <contains>declaration</contains>
+    <contains>element</contains>
+    <contains>wooga</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.yaml
@@ -1,0 +1,18 @@
+---
+wooga:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-alien.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>not allowed</contains>
+    <contains>wooga</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.json
@@ -1,0 +1,30 @@
+ {
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+                "value": ["{0}"],
+                "multiValue": 55
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.json.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>integer</contains>
+    <contains>does not match</contains>
+    <contains>boolean</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="55"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>55</contains>
+    <contains>boolean</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.yaml
@@ -1,0 +1,18 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: 55
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-local.yaml.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>integer</contains>
+    <contains>does not match</contains>
+    <contains>boolean</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.json
@@ -1,0 +1,30 @@
+{
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue": 55
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+                "value": ["{0}"],
+                "multiValue": true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.json.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>integer</contains>
+    <contains>does not match</contains>
+    <contains>boolean</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="55"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>55</contains>
+    <contains>boolean</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.yaml
@@ -1,0 +1,18 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: 55
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-bool-remote.yaml.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>integer</contains>
+    <contains>does not match</contains>
+    <contains>boolean</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.json
@@ -1,0 +1,33 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+    ],
+    "namespaces" : {
+          "fo::" : "http://fo-bar.com/won't/work"
+    },
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>fo::</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.yaml
@@ -1,0 +1,20 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  namespaces:
+    "fo::" : "http://fo-bar.com/won't/work"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-ns.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>fo::</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.json
@@ -1,0 +1,33 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+              "name": {
+                  "value" : "{D}",
+                  "type" : "xs:integer"
+              },
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.json.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>type should always be xs:string</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}" type="xs:integer"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.xml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>type should always be xs:string</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.yaml
@@ -1,0 +1,20 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name:
+          value: "{D}"
+          type: "xs:integer"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-type.yaml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+   <contains>type should always be xs:string</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.json
@@ -1,0 +1,30 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-12"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>RAX-12</contains>
+    <contains>version</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-12">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>RAX-12</contains>
+    <contains>version</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.yaml
@@ -1,0 +1,18 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-12

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-bad-version.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>RAX-12</contains>
+    <contains>version</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.json
@@ -1,0 +1,31 @@
+ {
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+              "expire":"{D}",
+              "extra" : null
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.json.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>not</contains>
+    <contains>allowed</contains>
+    <contains>extra</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+               <extra />
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.xml.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>declaration</contains>
+    <contains>element</contains>
+    <contains>extra</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.yaml
@@ -1,0 +1,19 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+        extra: null
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-ext-novalue.yaml.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>not</contains>
+    <contains>allowed</contains>
+    <contains>extra</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.json
@@ -1,0 +1,31 @@
+ {
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+                "value": ["{0}"],
+                "multiValue":true,
+                "extra" : "stuff"
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true" extra="stuff"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.yaml
@@ -1,0 +1,19 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+          extra: "stuff"
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-local.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.json
@@ -1,0 +1,31 @@
+ {
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true,
+            "extra" : "stuff"
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+                "value": ["{0}"],
+                "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group"
+                       multiValue="true" extra="stuff"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.yaml
@@ -1,0 +1,19 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+      extra: "stuff"
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra-remote.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.json
@@ -1,0 +1,31 @@
+ {
+   "mapping": {
+    "extra" : null,
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <extra />
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.xml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.yaml
@@ -1,0 +1,19 @@
+---
+mapping:
+  extra: null
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-extra.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>extra</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.json
@@ -1,0 +1,31 @@
+ {
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+               "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+               "multiValue":true,
+               "path" : "true()"
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+                "value": ["{0}"],
+                "multiValue": true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>path</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group"
+                       path="true()" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>path</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.yaml
@@ -1,0 +1,19 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+      path: true()
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-name-and-path.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>path</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-nons.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-nons.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Missing namespace!  This error can't be replicated in YAML or JSON,
+  because namespaces there only come into play in XPath validation
+  instead of the defination of the policy itself.
+ -->
+<mapping version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-nons.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-nons.xml.errors
@@ -1,0 +1,6 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>Cannot</contains>
+    <contains>declaration</contains>
+    <contains>element</contains>
+    <contains>mapping</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.json
@@ -1,0 +1,32 @@
+ {
+   "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+               "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+               "multiValue":true,
+               "whitelist" : ["foo", "bar"],
+               "blacklist" : "biz"
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+                "value": ["{0}"],
+                "multiValue": true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.json.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>can't have both a whitelist and a blacklist</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group"
+                       whitelist="foo bar" blacklist="biz" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.xml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>can't have both a whitelist and a blacklist</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.yaml
@@ -1,0 +1,20 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+      whitelist: ["foo", "bar"]
+      blacklist: "biz"
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs-whitelist-blacklist.yaml.errors
@@ -1,0 +1,3 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>can't have both a whitelist and a blacklist</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.json
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.json
@@ -1,0 +1,31 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true,
+              "booga" : true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.json.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>booga</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.xml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true" booga="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.xml.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>booga</contains>
+    <contains>is not allowed</contains>
+    <contains>roles</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.yaml
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.yaml
@@ -1,0 +1,19 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006'
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+          booga: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/invalid/adfs/maps/adfs.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>booga</contains>
+    <contains>not allowed</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/asserts/sample_assert.xml
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/asserts/sample_assert.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Include all common assertions -->
+<?include ../../../include/common-asserts.xml?>
+
+<!-- Include all adfs-specific assertions -->
+<?include ../../../include/adfs-asserts.xml?>
+
+<!-- The roles should be set -->
+<?assert every $r in ('Domain Users','RAX-identity~admin','RAX-nova~admin','RACK-Domain-5821005') satisfies $r=mapping:get-attributes('roles')?>
+
+<samlp:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"
+    Destination="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"
+    ID="_1105c5b8-28d4-45e5-a6e4-bc4179f5a111" IssueInstant="2016-11-18T18:54:55.572Z" Version="2.0"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_1105c5b8-28d4-45e5-a6e4-bc4179f5a111">
+                <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>JaeeD+wkw297KPF+BKpdacRtaPmQKFD+DqXQ3JE3Aus=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>kDBwO3xYaxITVS7ZZIy9AGOlk16Y5E0BlqU12QlRpWGfiwjtgok4p5q3YQS+N/Pxh84JUIjd7i+n0to/2yJyaCfoSA2SIUUf448lTtHNzVmjiC4WiUmUTRGaxUpsdcYUkjFAVAS40yGDBLXMYn/JYS4cbRV52/RTJ5smCCpqBMjgzhVaeAqJif/gXGjvMLl4RFN8JGvHZGzpjCb14UdKhVqfP0ZumLo4cLIWd3Ch49zRBQBgchbFqEJbTdPPLTJ4SMIEYm5RwX4PtQ2Ce94u8IGXkIhYf32H43l+955a35XGh37hcZMLZEzjk4FBMqSScupKqDej1c0m34MkeRGMlQ==</ds:SignatureValue>
+        <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+                <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+            </ds:X509Data>
+        </KeyInfo>
+    </ds:Signature>
+    <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+    <Assertion ID="_a8a6920c-d4eb-467f-85df-6fa2767ae63d" IssueInstant="2016-11-18T18:54:55.571Z"
+        Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+        <Issuer>http://adfs.contosowidgets.com/adfs/services/trust</Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+                    <ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>uQmSKQT03SRunafqzpb6v159a+jMVvTqmBCFYn17e7s=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>cYKqfE92hWqaPylJIcl89U9TKNzJXcFIPO0fvohg70zLB4JWnYlIKOz7S9XFUvS24mN47XS1T8DeR0IGITBMhqA/GCM624SOW0QjIRhQ9gh6/ONlyuAxGbVDo5tYb82sICFa9sMWI2Vr5ZH2LeTqyvsBRnlWBkZIw4hS2PBDHbhcnILUGX9uUDRcOrONAEMimnB7cNmZxSwQgdPfupyS39oedrUAiORa7GMII8GglWoj6Jy8SX0fQKXfsXD+wC5XFw76WAKJjSCuEkrXfxMQia/2H1tE24zNgZd6Y+uQ2Nh8YlUvO+DaMoj7mTKZUBqlxQt6It4kGH0+hfqvWx1MHQ==</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIC6jCCAdKgAwIBAgIQE+gZKcmH841I4gYjUiHCSDANBgkqhkiG9w0BAQsFADAxMS8wLQYDVQQDEyZBREZTIFNpZ25pbmcgLSBhZGZzLmNvbnRvc293aWRnZXRzLmNvbTAeFw0xNjA2MTYwMDUyNTZaFw0xNzA2MTYwMDUyNTZaMDExLzAtBgNVBAMTJkFERlMgU2lnbmluZyAtIGFkZnMuY29udG9zb3dpZGdldHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAna30lllMTaivaXPCjrW7VcRI6BsPs0iVxV559I9UONENSldX9pYTPlqLzxTP1RAVzfbGNoSvNelXrc0cb6jslgi+0Ya0jxrj1CsxQDgLtZeZchwWUYnJgsvk/HHfXiQBrWPLaZbImPNVvzG1zlYoQyQHTe1Nvr1m5Lv9foruSnw4My2LP4M27ZLPGL7rLaqpBg0E9sMX0iIrucNNN6AdyyPsR8oAUtV//QB49pCk+/rb3UtSDyGrdFFD+sJBDiAXYjTGzzYxYnMjckBZQfPKMWRntGwe7lM1KkX7mtUr9pNSvX1mQS/PHxhIcvO7aWKc15FJKzFmtdAEM2mvZjnCtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBj5cSPBQGyICJZHsMXA2KddWxSUqtYSBDPWYVsW9gJSMYiJBjdEnR1aGpw5K6iYei7KCACH717VQNfEF64qnBCbOvWc7FmZ3V0n4plfyZYuexbbZqp7RTi+J1q2xPsdb8MB7138YhXCc3Uf1p0oEuw+hKZ5rt4srcfgxuEauKXhnaI/UAOWOgDslzTuku+ogPsHBkc7wfH2CS9UqA3JUVJksR42yMg/Y47DUTp0Ma02RoVIfjFh+y3lX01O7B3ccCCdiKaSxcnLQ8n/ypn7LBhUUWDWZVIBj1flioohFMc5gU2Jl2Ueki72yxOwKVehqYgBHLPZBCUQUJDnUsbJJgb</ds:X509Certificate>
+                </ds:X509Data>
+            </KeyInfo>
+        </ds:Signature>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">btables@contosowidgets.loc</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData NotOnOrAfter="2016-11-18T18:59:55.572Z"
+                Recipient="https://astra-pysaml-staging2.astra.rackspace.com/v2/acs"/></SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2016-11-18T18:54:55.551Z" NotOnOrAfter="2016-11-18T19:54:55.551Z">
+            <AudienceRestriction>
+                <Audience>https://astra-pysaml-staging2.astra.rackspace.com/v2</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+                <AttributeValue>btables@contosowidgets.loc</AttributeValue>
+            </Attribute>
+            <Attribute Name="domain">
+                <AttributeValue>5821005</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+                <AttributeValue>Domain Users</AttributeValue>
+                <AttributeValue>RAX-identity~admin</AttributeValue>
+                <AttributeValue>RAX-nova~admin</AttributeValue>
+                <AttributeValue>RACK-Domain-5821005</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2016-11-18T18:30:55.359Z"
+            SessionIndex="_a8a6920c-d4eb-467f-85df-6fa2767ae63d">
+            <AuthnContext>
+                <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.json
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.json
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.json.errors
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.json.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>Unexpected character</contains>
+    <contains>'&lt;'</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.xml
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.xml
@@ -1,0 +1,30 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.xml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>Content is not allowed in prolog</contains>
+    <contains>lineNumber: 1</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.yaml
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.yaml
@@ -1,0 +1,30 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}",
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs-mislabled.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>line 7</contains>
+    <contains>unknown escape character /</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.json
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.json
@@ -1,0 +1,30 @@
+ {
+  "mapping": {
+    "rules": [
+       {
+        "remote": [
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/claims\/Group",
+            "multiValue":true
+           },
+           {
+            "name":"http:\/\/schemas.xmlsoap.org\/ws\/2005\/05\/identity\/claims\/emailaddress"
+           }
+         ],
+        "local": {
+          "user": {
+            "domain":"5821006",
+            "name":"{D}"
+            "email":"{1}",
+            "roles": {
+              "value": ["{0}"],
+              "multiValue":true
+             },
+            "expire":"{D}"
+           }
+         }
+       }
+     ],
+    "version":"RAX-1"
+   }
+ }

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.json.errors
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.json.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>Unexpected character</contains>
+    <contains>'"'</contains>
+    <contains>expecting comma</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.xml
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema"
+         version="RAX-1">
+   <rules>
+      <rule>
+         <local>
+            <user>
+               <domain value="5821006"/>
+               <name value="{D}"/>
+               <email value="{1}"/>
+               <roles value="{0}" multiValue="true"/>
+               <expire value="{D}"/>
+            </user>
+         </local>
+         <remote>
+            <attribute name="http://schemas.xmlsoap.org/claims/Group" multiValue="true"/>
+            <attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/
+         </remote>
+      </rule>
+   </rules>
+</mapping>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.xml.errors
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.xml.errors
@@ -1,0 +1,5 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>attribute</contains>
+    <contains>"&gt;" or "/&gt;"</contains>
+    <contains>lineNumber: 19</contains>
+</error-message>

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.yaml
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.yaml
@@ -1,0 +1,18 @@
+---
+mapping:
+  rules:
+  - remote:
+    - name: http://schemas.xmlsoap.org/claims/Group
+      multiValue: true
+    - name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+    local:
+      user:
+        domain: '5821006
+        name: "{D}"
+        email: "{1}"
+        roles:
+          value:
+            - "{0}"
+          multiValue: true
+        expire: "{D}"
+  version: RAX-1

--- a/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.yaml.errors
+++ b/core/src/test/resources/tests/bad-maps/malformed/adfs/maps/adfs.yaml.errors
@@ -1,0 +1,4 @@
+<error-message xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules">
+    <contains>line 10</contains>
+    <contains>domain</contains>
+</error-message>

--- a/core/src/test/resources/xsd/error-message.xsd
+++ b/core/src/test/resources/xsd/error-message.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema elementFormDefault="qualified"
+           targetNamespace="http://docs.rackspace.com/identity/api/ext/MappingRules"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:mapping='http://docs.rackspace.com/identity/api/ext/MappingRules'>
+
+    <xs:element name="error-message" type="mapping:ErrorMessage"/>
+
+    <xs:complexType name="ErrorMessage">
+        <xs:all>
+            <xs:element name="contains" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:all>
+    </xs:complexType>
+</xs:schema>

--- a/core/src/test/scala/com/rackspace/identity/components/AttributeMapperExceptionSuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/AttributeMapperExceptionSuite.scala
@@ -1,0 +1,159 @@
+/**
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.identity.components
+
+import java.io.File
+
+import javax.xml.transform.Source
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamSource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+import net.sf.saxon.s9api._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+import scala.reflect.ClassTag
+
+@RunWith(classOf[JUnitRunner])
+class AttributeMapperExceptionSuite extends AttributeMapperBase {
+
+  lazy val errorMessageSchema = schemaFactory.newSchema (new StreamSource(getClass.getResource("/xsd/error-message.xsd").toString))
+
+  val testDir = new File("src/test/resources/tests/bad-maps")
+
+  def getMapsFromTest (test : File) : List[File] = new File(test, "maps").listFiles().toList.filter(f => {
+    f.toString.endsWith("xml") || f.toString.endsWith("json") || f.toString.endsWith("yaml")})
+  def getAssertsFromTest (test : File) : List[File] = new File(test, "asserts").listFiles().toList.filter(f => {f.toString.endsWith("xml")})
+
+  type MapperTest = (File /* map */, File /* assertion */, String /* validation engine */,
+                    Seq[String] /* Error Strings */) => Unit /* Were're testing exceptional cases so no result */
+
+  def getErrorMessageStrings (map : File) : Seq[String] = {
+    val messageFileName = map.toString + ".errors"
+    //
+    //  Validate the error message file...
+    //
+    errorMessageSchema.newValidator.validate(new StreamSource(messageFileName))
+
+    //
+    //  Return a list of error message strings
+    //
+    val messageFile = XML.load(messageFileName)
+    (messageFile \\ "contains").map(_.text)
+  }
+
+  def runTests(subTestName : String, description : String, mapperTest : MapperTest) : Unit = {
+    val subTestDir = new File(testDir, subTestName)
+    val tests : List[File] = subTestDir.listFiles.toList.filter(f=>f.isDirectory)
+      tests.foreach( t => {
+        val maps : List[File] = getMapsFromTest(t)
+        val asserts : List[File] = getAssertsFromTest(t)
+
+        maps.foreach ( map => {
+          asserts.foreach ( assertFile => {
+            validators.foreach (v => {
+              test (s"$description ($map on $assertFile validated with $v)") {
+                  mapperTest(map, assertFile, v, getErrorMessageStrings(map))
+              }
+            })
+          })
+        })
+      })
+  }
+
+  def mapStreamSourceXDMDest(map : File, assertFile : File, validator : String ) : Unit = {
+    val mapFormat = map.getName.substring(map.getName.lastIndexOf('.') + 1).toLowerCase
+    val dest = new XdmDestination
+    AttributeMapper.convertAssertion (
+      new StreamSource(map),
+      PolicyFormat.withName(mapFormat),
+      new StreamSource(assertFile),
+      dest,
+      true,
+      true,
+      validator, Map("domain"->"foo:999-882"))
+  }
+
+  def mapNodeSourceNodeDest(map : File, assertFile : File, validator : String) : Unit = {
+    var docBuilder : javax.xml.parsers.DocumentBuilder = null
+    try {
+      docBuilder = borrowParser
+      val mapFormat = map.getName.substring(map.getName.lastIndexOf('.') + 1).toLowerCase
+      val policyExec : XsltExecutable = PolicyFormat.withName(mapFormat) match {
+        case PolicyFormat.JSON =>
+          val om = new ObjectMapper()
+          val jsonPolicy = om.readTree(map)
+          //
+          //  We double validate to make sure validation call works
+          //
+          AttributeMapper.generateXSLExec (AttributeMapper.validatePolicy(jsonPolicy, validator), true, validator)
+        case PolicyFormat.YAML =>
+          val jsonPolicy = AttributeMapper.parseYamlNode(new StreamSource(map))
+          //
+          //  We double validate to make sure validation call works
+          //
+          AttributeMapper.generateXSLExec (AttributeMapper.validatePolicy(jsonPolicy, validator), true, validator)
+        case PolicyFormat.XML =>
+          AttributeMapper.generateXSLExec (docBuilder.parse(map), true, validator)
+      }
+
+          val resultDoc = AttributeMapper.convertAssertion (policyExec, docBuilder.parse(assertFile), Map("domain"->"foo:999-882"))
+    } finally {
+      if (docBuilder != null) returnParser(docBuilder)
+    }
+  }
+
+  def doTest[T <: Exception](subTestName : String, description : String,
+    runner : (File, File, String) => Unit)(implicit m : Manifest[T]) : Unit = {
+    runTests(subTestName, description,
+      (map : File, assertFile : File, v : String, errorMessageStrings : Seq[String]) => {
+        print (s"Running $map or $assertFile") // scalastyle:ignore
+        val e = intercept[T] {
+          runner(map, assertFile, v)
+        }
+        val msg = e.getMessage
+        println (s"...$msg") // scalastyle:ignore
+        errorMessageStrings.foreach ( s =>
+          assert(msg.contains(s))
+        )
+      })
+  }
+
+  doTest[ParseException]("malformed",
+    "Stream Source and XDM Dest Malformed Data should fail with ParseException",
+    mapStreamSourceXDMDest)
+
+  doTest[ValidationException]("invalid",
+    "Stream Source and XDM Dest Invalid policy should fail with ValidationException",
+    mapStreamSourceXDMDest)
+
+  doTest[ValidationException]("invalid",
+    "Node Source and Node Dest Invalid policy should fail with ValidationException",
+    mapNodeSourceNodeDest)
+
+  doTest[XPathException]("invalid-xpath",
+    "Stream Source and XDM Dest Invalid xpath in policy should fail with XPathException",
+    mapStreamSourceXDMDest)
+
+  doTest[XPathException]("invalid-xpath",
+    "Node Source and Node Dest Invalid xpath in policy should fail with XPathException",
+    mapNodeSourceNodeDest)
+
+}

--- a/core/src/test/scala/com/rackspace/identity/components/ExtractExtensionSuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/ExtractExtensionSuite.scala
@@ -20,7 +20,6 @@ import java.io.File
 
 import javax.xml.xpath.XPathExpression
 import javax.xml.xpath.XPathConstants
-import javax.xml.xpath.XPathException
 
 import javax.xml.transform.Source
 import javax.xml.transform.stream.StreamSource
@@ -204,7 +203,7 @@ class ExtractExtensionSuite extends AttributeMapperBase with XPathAssertions {
       exp = borrowExpression(xpathString,nsContext, XPATH_VERSION)
       exp.evaluate (assert, XPathConstants.BOOLEAN).asInstanceOf[Boolean]
     } catch {
-      case xpe : XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
+      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
       case tf : TestFailedException => throw tf
       case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", 4) // scalastyle:ignore
     } finally {

--- a/core/src/test/scala/com/rackspace/identity/components/ExtractExtensionSuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/ExtractExtensionSuite.scala
@@ -15,33 +15,21 @@
  */
 package com.rackspace.identity.components
 
-import java.io.ByteArrayOutputStream
-import java.io.File
+import java.io.{ByteArrayOutputStream, File}
 
-import javax.xml.xpath.XPathExpression
-import javax.xml.xpath.XPathConstants
-
-import javax.xml.transform.Source
-import javax.xml.transform.stream.StreamSource
-import javax.xml.transform.dom.DOMSource
-
-import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
 import com.rackspace.com.papi.components.checker.util.XPathExpressionPool._
-
-
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.FunSuite
-
+import com.rackspace.identity.components.TestConstants.FAILED_TEST_STACK_DEPTH
+import javax.xml.transform.Source
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamSource
+import javax.xml.xpath.{XPathConstants, XPathExpression}
 import net.sf.saxon.s9api._
-import net.sf.saxon.Configuration.LicenseFeature._
-
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-
+import org.junit.runner.RunWith
 import org.scalatest.exceptions.TestFailedException
-
+import org.scalatest.junit.JUnitRunner
 import org.w3c.dom.Document
 
 @RunWith(classOf[JUnitRunner])
@@ -203,9 +191,9 @@ class ExtractExtensionSuite extends AttributeMapperBase with XPathAssertions {
       exp = borrowExpression(xpathString,nsContext, XPATH_VERSION)
       exp.evaluate (assert, XPathConstants.BOOLEAN).asInstanceOf[Boolean]
     } catch {
-      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
+      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, FAILED_TEST_STACK_DEPTH)
       case tf : TestFailedException => throw tf
-      case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", 4) // scalastyle:ignore
+      case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", FAILED_TEST_STACK_DEPTH)
     } finally {
       if (exp != null) returnExpression (xpathString, nsContext, XPATH_VERSION, exp)
     }

--- a/core/src/test/scala/com/rackspace/identity/components/TestConstants.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/TestConstants.scala
@@ -1,0 +1,20 @@
+/**
+  *   Copyright 2016 Rackspace US, Inc.
+  *
+  *   Licensed under the Apache License, Version 2.0 (the "License");
+  *   you may not use this file except in compliance with the License.
+  *   You may obtain a copy of the License at
+  *
+  *       http://www.apache.org/licenses/LICENSE-2.0
+  *
+  *   Unless required by applicable law or agreed to in writing, software
+  *   distributed under the License is distributed on an "AS IS" BASIS,
+  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *   See the License for the specific language governing permissions and
+  *   limitations under the License.
+  */
+package com.rackspace.identity.components
+
+object TestConstants {
+  final val FAILED_TEST_STACK_DEPTH: Int = 4
+}

--- a/core/src/test/scala/com/rackspace/identity/components/ValidatePolicySuite.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/ValidatePolicySuite.scala
@@ -18,7 +18,6 @@ package com.rackspace.identity.components
 import java.io.File
 import javax.xml.transform.stream.StreamSource
 
-import net.sf.saxon.trans.XPathException
 import net.sf.saxon.s9api.XdmDestination
 import org.junit.runner.RunWith
 import org.scalatest.Matchers

--- a/core/src/test/scala/com/rackspace/identity/components/XPathAssertions.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/XPathAssertions.scala
@@ -15,26 +15,18 @@
  */
 package com.rackspace.identity.components
 
-import scala.collection.mutable.Map
-import scala.collection.mutable.HashMap
-
-import javax.xml.transform.Source
-import javax.xml.namespace.QName
-
-import javax.xml.xpath.XPathExpression
-import javax.xml.xpath.XPathConstants
-
-import org.scalatest.exceptions.TestFailedException
-
 import com.fasterxml.jackson.databind.JsonNode
-
-import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
-import com.rackspace.com.papi.components.checker.util.XPathExpressionPool._
-import com.rackspace.com.papi.components.checker.util.XMLParserPool._
 import com.rackspace.com.papi.components.checker.util.JSONConverter._
-import com.rackspace.com.papi.components.checker.util.VarXPathExpression
-
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+import com.rackspace.com.papi.components.checker.util.XPathExpressionPool._
+import com.rackspace.com.papi.components.checker.util.{ImmutableNamespaceContext, VarXPathExpression}
+import com.rackspace.identity.components.TestConstants.FAILED_TEST_STACK_DEPTH
+import javax.xml.namespace.QName
+import javax.xml.xpath.{XPathConstants, XPathExpression}
+import org.scalatest.exceptions.TestFailedException
 import org.w3c.dom.Document
+
+import scala.collection.mutable.{HashMap, Map}
 
 object XPathAssertions {
   val XPATH_VERSION = 31
@@ -64,12 +56,12 @@ trait XPathAssertions {
     try {
       exp = borrowExpression(xpathString, nsContext, XPATH_VERSION)
       if (!exp.evaluate(src, XPathConstants.BOOLEAN).asInstanceOf[Boolean]) {
-        throw new TestFailedException (s"XPath expression does not evaluate to true(): $xpathString", 4) // scalastyle:ignore
+        throw new TestFailedException (s"XPath expression does not evaluate to true(): $xpathString", FAILED_TEST_STACK_DEPTH)
       }
     } catch {
-      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
+      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, FAILED_TEST_STACK_DEPTH)
       case tf : TestFailedException => throw tf
-      case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", 4) // scalastyle:ignore
+      case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", FAILED_TEST_STACK_DEPTH)
     } finally {
       if (exp != null) returnExpression (xpathString, nsContext, XPATH_VERSION, exp)
     }
@@ -83,12 +75,12 @@ trait XPathAssertions {
     try {
       exp = borrowExpression(xpathString, nsContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
       if (!exp.evaluate(inDoc, XPathConstants.BOOLEAN, vars).asInstanceOf[Boolean]) {
-        throw new TestFailedException (s"XPath expression does not evaluate to true(): $xpathString", 4) // scalastyle:ignore
+        throw new TestFailedException (s"XPath expression does not evaluate to true(): $xpathString", FAILED_TEST_STACK_DEPTH)
       }
     } catch {
-      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
+      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, FAILED_TEST_STACK_DEPTH)
       case tf : TestFailedException => throw tf
-      case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", 4) // scalastyle:ignore
+      case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", FAILED_TEST_STACK_DEPTH)
     } finally {
       if (exp != null) returnExpression (xpathString, nsContext, XPATH_VERSION, exp)
     }

--- a/core/src/test/scala/com/rackspace/identity/components/XPathAssertions.scala
+++ b/core/src/test/scala/com/rackspace/identity/components/XPathAssertions.scala
@@ -23,7 +23,6 @@ import javax.xml.namespace.QName
 
 import javax.xml.xpath.XPathExpression
 import javax.xml.xpath.XPathConstants
-import javax.xml.xpath.XPathException
 
 import org.scalatest.exceptions.TestFailedException
 
@@ -68,7 +67,7 @@ trait XPathAssertions {
         throw new TestFailedException (s"XPath expression does not evaluate to true(): $xpathString", 4) // scalastyle:ignore
       }
     } catch {
-      case xpe : XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
+      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
       case tf : TestFailedException => throw tf
       case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", 4) // scalastyle:ignore
     } finally {
@@ -87,7 +86,7 @@ trait XPathAssertions {
         throw new TestFailedException (s"XPath expression does not evaluate to true(): $xpathString", 4) // scalastyle:ignore
       }
     } catch {
-      case xpe : XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
+      case xpe : javax.xml.xpath.XPathException => throw new TestFailedException (s"Error in XPath $xpathString", xpe, 4) // scalastyle:ignore
       case tf : TestFailedException => throw tf
       case unknown : Throwable => throw new TestFailedException(s"Unknown error in XPath $xpathString", 4) // scalastyle:ignore
     } finally {


### PR DESCRIPTION
This PR replaces #77.

From the description of #77:
> All exceptions provided by attribute mapper will now be derived from
> AttributeMapperException.
> 
> Also provide a new JSON Schema to validate JSON/YAML policies in order
> to get meaningful error messages.
> 
> The following are the description of new exceptions:
> 
> AttributeMapperException extends Exception:
> 
> Base class for all other exceptions. This is also used to wrap
> exceptions we don't understand. In this case, the message will be
> generic : "Error while processing mapping policy". This may be an
> internal issue with the attribute mapper.
> 
> KnownAttributeMapperException extends AttributeMapperException:
> 
> Base class for all "known" exceptions. In this case the message is
> specific to the exception and may be sent to the end user.
> 
> ParseException extends KnownAttributeMapperException:
> 
> Malformed XML, JSON, YAML.
> 
> ValidationException extends KnownAttributeMapperException:
> 
> There's a validation error -- something which validates XSD or
> JsonSchema.
> 
> XPathException extends ValidationException
> 
> There's an issue with an XPath in the policy.